### PR TITLE
registry: ensure model mismatch detection is also triggered when downloading all tags

### DIFF
--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -51,6 +51,7 @@ import oras.oci
 import oras.provider
 
 from abstracts_explorer._version import __version__
+from abstracts_explorer.config import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -306,18 +307,15 @@ class RegistryClient:
     @staticmethod
     def _get_embedding_model() -> Optional[str]:
         """
-        Return the embedding model stored in the local database.
+        Return the embedding model from the config.
 
         Returns
         -------
         str or None
             Embedding model name, or ``None`` if not set.
         """
-        from abstracts_explorer.database import DatabaseManager
-
-        with DatabaseManager() as db:
-            db.create_tables()
-            return db.get_embedding_model()
+        config = get_config()
+        return config.embedding_model
 
     def _find_best_matching_tag(self, tag: str) -> str:
         """
@@ -892,14 +890,14 @@ class RegistryClient:
         RegistryError
             If download fails or the embedding model cannot be determined.
         """
+        if embedding_model is None:
+            embedding_model = self._get_embedding_model()
+        if not embedding_model:
+            raise RegistryError(
+                "No embedding model specified and none found in the configuration. "
+                "Use --embedding-model to specify the model name."
+            )
         if tag is None:
-            if embedding_model is None:
-                embedding_model = self._get_embedding_model()
-            if not embedding_model:
-                raise RegistryError(
-                    "No embedding model specified and none found in local database. "
-                    "Use --embedding-model to specify the model name."
-                )
             tag = _build_tag(conference, year, embedding_model=embedding_model)
 
         def _progress(msg: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,37 @@ from abstracts_explorer.plugin import LightweightPaper
 from abstracts_explorer.config import get_config
 
 
+# Helper context to temporarily clear environment variables for testing config loading behavior
+class EnvClearer:
+    """
+    Context manager to temporarily clear environment variables.
+
+    This is useful for testing configuration loading behavior when no environment
+    variables are set, ensuring that the system falls back to .env files or defaults.
+    """
+
+    def __init__(self, *env_vars):
+        self.env_vars = env_vars
+        self.original_values = {}
+
+    def __enter__(self):
+        import os
+
+        for var in self.env_vars:
+            self.original_values[var] = os.environ.get(var)
+            if var in os.environ:
+                del os.environ[var]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import os
+
+        for var, value in self.original_values.items():
+            if value is not None:
+                os.environ[var] = value
+            elif var in os.environ:
+                del os.environ[var]
+
+
 def get_env_test_path() -> Path:
     """
     Get the path to the .env.tests file.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from abstracts_explorer.config import Config, get_config, load_env_file
 from abstracts_explorer import config as config_module
 
-from tests.conftest import get_env_test_path
+from tests.conftest import get_env_test_path, EnvClearer
 
 
 class TestLoadEnvFile:
@@ -315,22 +315,27 @@ PAPER_DB=/absolute/path/to/papers.db
     def test_config_default_conference_and_year(self, tmp_path):
         """Test that DEFAULT_CONFERENCE and DEFAULT_YEAR can be configured."""
         env_file = tmp_path / ".env"
-        env_file.write_text("""
-DEFAULT_CONFERENCE=NeurIPS
-DEFAULT_YEAR=2024
-""")
+        env_file.write_text(
+            """
+DEFAULT_CONFERENCE=MadeUp
+DEFAULT_YEAR=2224
+"""
+        )
 
-        config = Config(env_path=env_file)
+        # clear os.environ to prevent it from overriding .env file
+        with EnvClearer("DEFAULT_CONFERENCE", "DEFAULT_YEAR"):
+            config = Config(env_path=env_file)
 
-        assert config.default_conference == "NeurIPS"
-        assert config.default_year == 2024
+        assert config.default_conference == "MadeUp"
+        assert config.default_year == 2224
 
     def test_config_default_conference_and_year_defaults(self, tmp_path):
         """Test that DEFAULT_CONFERENCE defaults to 'ML4PS@NeurIPS' and DEFAULT_YEAR to 0."""
         env_file = tmp_path / ".env"
         env_file.write_text("")
 
-        config = Config(env_path=env_file)
+        with EnvClearer("DEFAULT_CONFERENCE", "DEFAULT_YEAR"):
+            config = Config(env_path=env_file)
 
         assert config.default_conference == "ML4PS@NeurIPS"
         assert config.default_year == 0


### PR DESCRIPTION
switched to using the configured model as the reference, instead of the model from the database. now embedding model is always set in  RegistryClient.download() always triggering the model mismatch detection