### PR TITLE
fix registry download all conferences

### DIFF
--- a/src/abstracts_explorer/cli.py
+++ b/src/abstracts_explorer/cli.py
@@ -1915,6 +1915,9 @@ def registry_download_command(args: argparse.Namespace) -> int:
             try:
                 summaries = client.download_all(
                     progress_callback=lambda msg: print(f"  {msg}"),
+                    ignore_embedding_model_mismatch=getattr(
+                        args, "ignore_embedding_model_mismatch", False
+                    ),
                 )
             except EmbeddingModelMismatchError as mismatch:
                 print(

--- a/src/abstracts_explorer/cli.py
+++ b/src/abstracts_explorer/cli.py
@@ -1909,6 +1909,8 @@ def registry_download_command(args: argparse.Namespace) -> int:
     try:
         client = RegistryClient(repository=repository, token=token)
 
+        embedding_model = getattr(args, "embedding_model", None) or config.embedding_model
+
         if conference == "all":
             try:
                 summaries = client.download_all(
@@ -1933,7 +1935,6 @@ def registry_download_command(args: argparse.Namespace) -> int:
                     f"{s.get('embedding_count', 0)} embeddings"
                 )
         else:
-            embedding_model = getattr(args, "embedding_model", None) or config.embedding_model
             ignore_embedding_model_mismatch = getattr(args, "ignore_embedding_model_mismatch", False)
 
             def _do_download():

--- a/src/abstracts_explorer/cli.py
+++ b/src/abstracts_explorer/cli.py
@@ -1910,14 +1910,13 @@ def registry_download_command(args: argparse.Namespace) -> int:
         client = RegistryClient(repository=repository, token=token)
 
         embedding_model = getattr(args, "embedding_model", None) or config.embedding_model
+        ignore_embedding_model_mismatch = getattr(args, "ignore_embedding_model_mismatch", False)
 
         if conference == "all":
             try:
                 summaries = client.download_all(
                     progress_callback=lambda msg: print(f"  {msg}"),
-                    ignore_embedding_model_mismatch=getattr(
-                        args, "ignore_embedding_model_mismatch", False
-                    ),
+                    ignore_embedding_model_mismatch=ignore_embedding_model_mismatch,
                 )
             except EmbeddingModelMismatchError as mismatch:
                 print(
@@ -1938,7 +1937,6 @@ def registry_download_command(args: argparse.Namespace) -> int:
                     f"{s.get('embedding_count', 0)} embeddings"
                 )
         else:
-            ignore_embedding_model_mismatch = getattr(args, "ignore_embedding_model_mismatch", False)
 
             def _do_download():
                 return client.download(

--- a/src/abstracts_explorer/cli.py
+++ b/src/abstracts_explorer/cli.py
@@ -1859,7 +1859,6 @@ def registry_download_command(args: argparse.Namespace) -> int:
         EmbeddingModelMismatchError,
         RegistryClient,
         RegistryError,
-        _sanitize_str_for_oci_tag,
     )
 
     config = get_config()
@@ -1912,34 +1911,21 @@ def registry_download_command(args: argparse.Namespace) -> int:
         embedding_model = getattr(args, "embedding_model", None) or config.embedding_model
         ignore_embedding_model_mismatch = getattr(args, "ignore_embedding_model_mismatch", False)
 
-        if conference == "all":
-            try:
+        try:
+            if conference == "all":
                 summaries = client.download_all(
                     progress_callback=lambda msg: print(f"  {msg}"),
                     ignore_embedding_model_mismatch=ignore_embedding_model_mismatch,
                 )
-            except EmbeddingModelMismatchError as mismatch:
-                print(
-                    f"\n❌ Embedding model mismatch:\n"
-                    f"  Configured model: '{embedding_model}'\n"
-                    f"  Artifact model:   '{mismatch.remote_model}'\n"
-                    f"\nIf both names refer to the same model on different backends,\n"
-                    f"you can use --ignore-embedding-model-mismatch to proceed.\n"
-                    f"⚠️  Only use this option if you are certain the models are identical!",
-                    file=sys.stderr,
-                )
-                return 1
 
-            print(f"\n✅ Download complete! Downloaded {len(summaries)} artifact(s).")
-            for s in summaries:
-                print(
-                    f"  📦 {s.get('conference', '')}: {s.get('paper_count', 0)} papers, "
-                    f"{s.get('embedding_count', 0)} embeddings"
-                )
-        else:
-
-            def _do_download():
-                return client.download(
+                print(f"\n✅ Download complete! Downloaded {len(summaries)} artifact(s).")
+                for s in summaries:
+                    print(
+                        f"  📦 {s.get('conference', '')}: {s.get('paper_count', 0)} papers, "
+                        f"{s.get('embedding_count', 0)} embeddings"
+                    )
+            else:
+                summary = client.download(
                     conference=conference,
                     year=args.year,
                     tag=args.tag,
@@ -1948,60 +1934,26 @@ def registry_download_command(args: argparse.Namespace) -> int:
                     ignore_embedding_model_mismatch=ignore_embedding_model_mismatch,
                 )
 
-            try:
-                summary = _do_download()
-            except EmbeddingModelMismatchError as mismatch:
-                # The local DB uses a different model than the remote artifact.
-                # If the configured model matches the remote model, offer to wipe
-                # local embedding data and retry.
-                if embedding_model and _sanitize_str_for_oci_tag(embedding_model) == _sanitize_str_for_oci_tag(
-                    mismatch.remote_model
-                ):
-                    print(
-                        f"\n⚠️  Embedding model mismatch detected:\n"
-                        f"  Local database:  '{mismatch.local_model}'\n"
-                        f"  Downloaded data: '{mismatch.remote_model}'\n"
-                        f"\nThe configured model ('{embedding_model}') matches the downloaded data.\n"
-                        f"To proceed, all local embeddings, clustering cache, and embedding metadata\n"
-                        f"must be cleared so the new model's data can be imported.\n"
-                        f"⚠️  This will delete ALL local embeddings and clustering cache!",
-                        file=sys.stderr,
-                    )
-                    if not args.yes:
-                        try:
-                            confirm = (
-                                input("Clear all local embedding data and retry download? [y/N]: ").strip().lower()
-                            )
-                        except (EOFError, KeyboardInterrupt):
-                            print("\nAborted.")
-                            return 1
-                        if confirm != "y":
-                            print("Aborted.")
-                            return 1
-                    print("  Clearing local embedding data...")
-                    RegistryClient.clear_local_embedding_data()
-                    print("  Local embedding data cleared. Retrying download...")
-                    summary = _do_download()
-                else:
-                    print(
-                        f"\n❌ Embedding model mismatch:\n"
-                        f"  Configured model: '{embedding_model}'\n"
-                        f"  Artifact model:   '{mismatch.remote_model}'\n"
-                        f"\nIf both names refer to the same model on different backends,\n"
-                        f"you can use --ignore-embedding-model-mismatch to proceed.\n"
-                        f"⚠️  Only use this option if you are certain the models are identical!",
-                        file=sys.stderr,
-                    )
-                    return 1
+                print("\n✅ Download complete!")
+                print(f"  📄 Papers:     {summary.get('paper_count', 0)}")
+                print(f"  🧮 Embeddings: {summary.get('embedding_count', 0)}")
+                print(f"  📅 Years:      {summary.get('years', [])}")
 
-            print("\n✅ Download complete!")
-            print(f"  📄 Papers:     {summary.get('paper_count', 0)}")
-            print(f"  🧮 Embeddings: {summary.get('embedding_count', 0)}")
-            print(f"  📅 Years:      {summary.get('years', [])}")
+                metadata = summary.get("metadata", {})
+                if metadata:
+                    print(f"\n  ℹ️  Artifact version: {metadata.get('version', 'unknown')}")
 
-            metadata = summary.get("metadata", {})
-            if metadata:
-                print(f"\n  ℹ️  Artifact version: {metadata.get('version', 'unknown')}")
+        except EmbeddingModelMismatchError as mismatch:
+            print(
+                f"\n❌ Embedding model mismatch:\n"
+                f"  Configured model: '{embedding_model}'\n"
+                f"  Artifact model:   '{mismatch.remote_model}'\n"
+                f"\nIf both names refer to the same model on different backends,\n"
+                f"you can use --ignore-embedding-model-mismatch to proceed.\n"
+                f"⚠️  Only use this option if you are certain the models are identical!",
+                file=sys.stderr,
+            )
+            return 1
 
         return 0
 

--- a/src/abstracts_explorer/cli.py
+++ b/src/abstracts_explorer/cli.py
@@ -1910,9 +1910,22 @@ def registry_download_command(args: argparse.Namespace) -> int:
         client = RegistryClient(repository=repository, token=token)
 
         if conference == "all":
-            summaries = client.download_all(
-                progress_callback=lambda msg: print(f"  {msg}"),
-            )
+            try:
+                summaries = client.download_all(
+                    progress_callback=lambda msg: print(f"  {msg}"),
+                )
+            except EmbeddingModelMismatchError as mismatch:
+                print(
+                    f"\n❌ Embedding model mismatch:\n"
+                    f"  Configured model: '{embedding_model}'\n"
+                    f"  Artifact model:   '{mismatch.remote_model}'\n"
+                    f"\nIf both names refer to the same model on different backends,\n"
+                    f"you can use --ignore-embedding-model-mismatch to proceed.\n"
+                    f"⚠️  Only use this option if you are certain the models are identical!",
+                    file=sys.stderr,
+                )
+                return 1
+
             print(f"\n✅ Download complete! Downloaded {len(summaries)} artifact(s).")
             for s in summaries:
                 print(

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -494,6 +494,110 @@ class RegistryClient:
             "embedding_count": embedding_count,
         }
 
+    @staticmethod
+    def _read_artifact_embedding_model(paper_db_file: Path) -> Optional[str]:
+        """
+        Read the embedding model name from the ``embeddings_metadata`` table
+        in a downloaded artifact's paper DB.
+
+        Parameters
+        ----------
+        paper_db_file : Path
+            Path to the artifact's SQLite paper database.
+
+        Returns
+        -------
+        str or None
+            The embedding model stored in the artifact, or ``None`` if
+            the table does not exist or is empty (legacy artifacts).
+        """
+        try:
+            with sqlite3.connect(str(paper_db_file)) as conn:
+                row = conn.execute(
+                    "SELECT embedding_model FROM embeddings_metadata ORDER BY updated_at DESC LIMIT 1"
+                ).fetchone()
+                return row[0] if row else None
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+            logger.debug("Could not read embedding model from artifact DB %s: %s", paper_db_file.name, exc)
+            return None
+
+    @staticmethod
+    def _replace_artifact_embedding_model(paper_db_file: Path, new_model: str) -> None:
+        """
+        Overwrite the embedding model in the artifact's paper DB so that
+        subsequent imports do not trigger model-consistency checks.
+
+        Parameters
+        ----------
+        paper_db_file : Path
+            Path to the artifact's SQLite paper database.
+        new_model : str
+            The model name to write.
+        """
+        try:
+            with sqlite3.connect(str(paper_db_file)) as conn:
+                conn.execute(
+                    "UPDATE embeddings_metadata SET embedding_model = ?",
+                    (new_model,),
+                )
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+            logger.debug("Could not update embedding model in artifact DB %s: %s", paper_db_file.name, exc)
+
+    @staticmethod
+    def _check_embedding_model(
+        paper_db_file: Path,
+        embedding_model: str,
+        ignore_embedding_model_mismatch: bool,
+        progress: Callable[[str], None],
+    ) -> None:
+        """
+        Single authoritative embedding-model check for one conference/year import.
+
+        Reads the model stored in the artifact paper DB and compares it to
+        *embedding_model*.  When the models differ:
+
+        * If *ignore_embedding_model_mismatch* is ``False``,
+          ``EmbeddingModelMismatchError`` is raised.
+        * If *ignore_embedding_model_mismatch* is ``True``, the artifact
+          DB is patched in-place so that the downstream
+          ``import_papers_from_sqlite()`` consistency check will not
+          trigger again.
+
+        Parameters
+        ----------
+        paper_db_file : Path
+            Path to the artifact's SQLite paper database.
+        embedding_model : str
+            The configured/expected embedding model name.
+        ignore_embedding_model_mismatch : bool
+            When ``True``, overwrite the artifact model and continue.
+        progress : callable
+            Status-message callback.
+
+        Raises
+        ------
+        EmbeddingModelMismatchError
+            When models differ and *ignore_embedding_model_mismatch* is ``False``.
+        """
+        artifact_model = RegistryClient._read_artifact_embedding_model(paper_db_file)
+        if not artifact_model:
+            return  # Legacy artifact without metadata — nothing to check
+
+        if _sanitize_str_for_oci_tag(artifact_model) == _sanitize_str_for_oci_tag(embedding_model):
+            return  # Models match — nothing to do
+
+        if not ignore_embedding_model_mismatch:
+            raise EmbeddingModelMismatchError(local_model=embedding_model, remote_model=artifact_model)
+
+        # Models differ but the user explicitly asked to proceed.
+        progress(
+            f"⚠️  Embedding model mismatch ignored for {paper_db_file.name}:\n"
+            f"  Configured model: '{embedding_model}'\n"
+            f"  Artifact model:   '{artifact_model}'\n"
+            f"  Replacing artifact model with configured model."
+        )
+        RegistryClient._replace_artifact_embedding_model(paper_db_file, embedding_model)
+
     def _import_year(
         self,
         conference: str,
@@ -512,9 +616,14 @@ class RegistryClient:
         rolled back to prevent inconsistency between the paper DB and the
         embedding DB.
 
-        Returns a dict with ``paper_count``, ``embedding_count``, and
-        ``mismatch_was_ignored`` (True if an embedding model mismatch was
-        detected but overridden via *ignore_embedding_model_mismatch*).
+        The embedding-model consistency check happens **here** — this is
+        the single authoritative location.  When
+        *ignore_embedding_model_mismatch* is ``True`` and the models
+        differ, the artifact DB is patched before the import so that the
+        downstream ``import_papers_from_sqlite()`` check will not trigger
+        again.
+
+        Returns a dict with ``paper_count`` and ``embedding_count``.
 
         Raises
         ------
@@ -539,42 +648,9 @@ class RegistryClient:
                 "Cannot import — both paper DB and embeddings must be present."
             )
 
-        # --- pre-flight: validate embedding model from artifact paper DB ---
-        # This check catches mismatches even when the local DB is empty (in which case
-        # the normal import_papers_from_sqlite() check is skipped).
-        mismatch_was_ignored = False
+        # --- single authoritative embedding-model check ---
         if embedding_model:
-            artifact_model: Optional[str] = None
-            try:
-                with sqlite3.connect(str(paper_db_file)) as conn:
-                    row = conn.execute(
-                        "SELECT embedding_model FROM embeddings_metadata ORDER BY updated_at DESC LIMIT 1"
-                    ).fetchone()
-                    if row:
-                        artifact_model = row[0]
-                    if ignore_embedding_model_mismatch:
-                        # replace the model in the artifact DB with the local model so that the import can proceed without triggering the mismatch check again later
-                        conn.execute(
-                            "UPDATE embeddings_metadata SET embedding_model = ?",
-                            (embedding_model,),
-                        )
-            except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
-                # Legacy DB without embeddings_metadata table or not a valid SQLite file
-                logger.debug("Could not read embedding model from artifact DB %s: %s", paper_db_file.name, exc)
-
-            if artifact_model and _sanitize_str_for_oci_tag(artifact_model) != _sanitize_str_for_oci_tag(
-                embedding_model
-            ):
-                if not ignore_embedding_model_mismatch:
-                    raise EmbeddingModelMismatchError(local_model=embedding_model, remote_model=artifact_model)
-                mismatch_was_ignored = True
-                logger.debug(
-                    f"⚠️  WARNING: Embedding model mismatch detected for {conference}/{year}!\n"
-                    f"  Configured model: '{embedding_model}'\n"
-                    f"  Artifact model:   '{artifact_model}'\n"
-                    f"  Proceeding because --ignore-embedding-model-mismatch was set.\n"
-                    f"  ⚠️  Only do this if both names refer to the same model on different backends!"
-                )
+            self._check_embedding_model(paper_db_file, embedding_model, ignore_embedding_model_mismatch, progress)
 
         # --- import paper DB first ---
         progress(f"Importing paper database for {conference}/{year}...")
@@ -622,7 +698,6 @@ class RegistryClient:
         return {
             "paper_count": paper_count,
             "embedding_count": embedding_count,
-            "mismatch_was_ignored": mismatch_was_ignored,
         }
 
     # ------------------------------------------------------------------
@@ -928,9 +1003,8 @@ class RegistryClient:
             target = f"{self.repository}:{tag}"
 
         # --- 0b. Pre-download: check embedding model from manifest labels ---
-        # Fetch the manifest before pulling any data so we can fail fast if
-        # the artifact was built with a different embedding model.
-        mismatch_was_ignored = False
+        # Fail fast before pulling data when the artifact's model does not
+        # match and the user has not opted to ignore the mismatch.
         manifest_embedding_model = self._get_manifest_embedding_model(target)
         if manifest_embedding_model and embedding_model:
             if _sanitize_str_for_oci_tag(manifest_embedding_model) != _sanitize_str_for_oci_tag(embedding_model):
@@ -939,14 +1013,6 @@ class RegistryClient:
                         local_model=embedding_model,
                         remote_model=manifest_embedding_model,
                     )
-                mismatch_was_ignored = True
-                _progress(
-                    f"⚠️  WARNING: Embedding model mismatch detected!\n"
-                    f"  Configured model: '{embedding_model}'\n"
-                    f"  Artifact model:   '{manifest_embedding_model}'\n"
-                    f"  Proceeding because --ignore-embedding-model-mismatch was set.\n"
-                    f"  ⚠️  Only do this if both names refer to the same model on different backends!"
-                )
 
         temp_dir = Path(tempfile.mkdtemp())
         try:
@@ -1035,21 +1101,10 @@ class RegistryClient:
                 )
                 total_papers += result["paper_count"]
                 total_embeddings += result["embedding_count"]
-                if result.get("mismatch_was_ignored"):
-                    mismatch_was_ignored = True
                 imported_years.append(yr)
 
             if not imported_years:
                 _progress("Warning: No data found in artifact to import")
-
-            # --- 5. Update local embedding model if mismatch was ignored ---
-            if mismatch_was_ignored and embedding_model:
-                from abstracts_explorer.database import DatabaseManager
-
-                _progress(f"Updating local embedding model metadata to configured model: '{embedding_model}'")
-                with DatabaseManager() as db:
-                    db.create_tables()
-                    db.set_embedding_model(embedding_model)
 
             _progress("Download complete!")
             return {

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -562,7 +562,7 @@ class RegistryClient:
                 if not ignore_embedding_model_mismatch:
                     raise EmbeddingModelMismatchError(local_model=embedding_model, remote_model=artifact_model)
                 mismatch_was_ignored = True
-                progress(
+                logger.debug(
                     f"⚠️  WARNING: Embedding model mismatch detected for {conference}/{year}!\n"
                     f"  Configured model: '{embedding_model}'\n"
                     f"  Artifact model:   '{artifact_model}'\n"

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -320,6 +320,35 @@ class RegistryClient:
             db.create_tables()
             return db.get_embedding_model()
 
+    @staticmethod
+    def _is_conference_level_tag(tag: str) -> bool:
+        """
+        Return ``True`` when *tag* is a conference-level tag (no year suffix).
+
+        OCI tags in this project have the format
+        ``{conference}[-{year}]_{model}_{version}``.  Year-specific tags
+        contain a ``-YYYY`` suffix in the base component (before the first
+        ``_``), e.g. ``chi-2026_model_0.4.1``.  Conference-level tags
+        omit the year, e.g. ``chi_model_0.4.1``.
+
+        Download operations should only use conference-level tags so that
+        each year is not imported twice (once from its dedicated year tag
+        and again from the combined conference tag).
+
+        Parameters
+        ----------
+        tag : str
+            OCI tag string (without repository prefix).
+
+        Returns
+        -------
+        bool
+            ``True`` if the tag does not carry a year suffix.
+        """
+        base = tag.split("_", 1)[0]
+        parts = base.rsplit("-", 1)
+        return not (len(parts) == 2 and parts[1].isdigit() and len(parts[1]) == 4)
+
     def _find_best_matching_tag(self, tag: str) -> str:
         """
         Resolve *tag* to the best matching tag available in the registry.
@@ -1211,15 +1240,22 @@ class RegistryClient:
         if not tags:
             raise RegistryError("No tags found in registry.")
 
+        # Only download conference-level tags (e.g. "chi_model_0.4.1").
+        # Year-specific tags (e.g. "chi-2026_model_0.4.1") are subsets of the
+        # conference tag and would cause each year to be imported twice.
+        conference_tags = [t for t in tags if self._is_conference_level_tag(t)]
+        if not conference_tags:
+            raise RegistryError("No conference-level tags found in registry.")
+
         def _progress(msg: str) -> None:
             if progress_callback:
                 progress_callback(msg)
             logger.info(msg)
 
-        _progress(f"Found {len(tags)} tag(s) in registry")
+        _progress(f"Found {len(conference_tags)} conference tag(s) in registry (skipping {len(tags) - len(conference_tags)} year-specific tag(s))")
 
         summaries: List[Dict[str, Any]] = []
-        for tag in sorted(tags):
+        for tag in sorted(conference_tags):
             _progress(f"\n--- Downloading {tag} ---")
             # Read manifest annotations to derive conference/year
             try:

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -1109,6 +1109,7 @@ class RegistryClient:
     def download_all(
         self,
         progress_callback: Optional[Callable[[str], None]] = None,
+        ignore_embedding_model_mismatch: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Download data for **all** conference tags in the registry.
@@ -1120,6 +1121,9 @@ class RegistryClient:
         ----------
         progress_callback : callable, optional
             Function called with status messages during download.
+
+        ignore_embedding_model_mismatch : bool, optional
+            If True, ignore embedding model mismatches during download.
 
         Returns
         -------
@@ -1184,6 +1188,7 @@ class RegistryClient:
                 year=yr,
                 tag=tag,
                 progress_callback=progress_callback,
+                ignore_embedding_model_mismatch=ignore_embedding_model_mismatch,
             )
             summaries.append(summary)
 

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -518,7 +518,12 @@ class RegistryClient:
                 ).fetchone()
                 return row[0] if row else None
         except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
-            logger.debug("Could not read embedding model from artifact DB %s: %s", paper_db_file.name, exc)
+            logger.debug(
+                "Could not read embedding model from artifact DB %s: %s: %s",
+                paper_db_file.name,
+                type(exc).__name__,
+                exc,
+            )
             return None
 
     @staticmethod
@@ -537,11 +542,17 @@ class RegistryClient:
         try:
             with sqlite3.connect(str(paper_db_file)) as conn:
                 conn.execute(
-                    "UPDATE embeddings_metadata SET embedding_model = ?",
+                    "UPDATE embeddings_metadata SET embedding_model = ? "
+                    "WHERE rowid = (SELECT rowid FROM embeddings_metadata ORDER BY updated_at DESC LIMIT 1)",
                     (new_model,),
                 )
         except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
-            logger.debug("Could not update embedding model in artifact DB %s: %s", paper_db_file.name, exc)
+            logger.debug(
+                "Could not update embedding model in artifact DB %s: %s: %s",
+                paper_db_file.name,
+                type(exc).__name__,
+                exc,
+            )
 
     @staticmethod
     def _check_embedding_model(

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -347,7 +347,11 @@ class RegistryClient:
         """
         base = tag.split("_", 1)[0]
         parts = base.rsplit("-", 1)
-        return not (len(parts) == 2 and parts[1].isdigit() and len(parts[1]) == 4)
+        if len(parts) != 2:
+            return True
+        suffix = parts[1]
+        # A year suffix is exactly 4 digits in a plausible conference year range.
+        return not (suffix.isdigit() and len(suffix) == 4 and 2000 <= int(suffix) <= 2099)
 
     def _find_best_matching_tag(self, tag: str) -> str:
         """
@@ -1252,7 +1256,9 @@ class RegistryClient:
                 progress_callback(msg)
             logger.info(msg)
 
-        _progress(f"Found {len(conference_tags)} conference tag(s) in registry (skipping {len(tags) - len(conference_tags)} year-specific tag(s))")
+        _progress(
+            f"Found {len(conference_tags)} conference tag(s) in registry (skipping {len(tags) - len(conference_tags)} year-specific tag(s))"
+        )
 
         summaries: List[Dict[str, Any]] = []
         for tag in sorted(conference_tags):

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -552,6 +552,12 @@ class RegistryClient:
                     ).fetchone()
                     if row:
                         artifact_model = row[0]
+                    if ignore_embedding_model_mismatch:
+                        # replace the model in the artifact DB with the local model so that the import can proceed without triggering the mismatch check again later
+                        conn.execute(
+                            "UPDATE embeddings_metadata SET embedding_model = ?",
+                            (embedding_model,),
+                        )
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
                 # Legacy DB without embeddings_metadata table or not a valid SQLite file
                 logger.debug("Could not read embedding model from artifact DB %s: %s", paper_db_file.name, exc)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1759,7 +1759,7 @@ class TestCLICommands:
         assert exc_info.value.remote_model == "artifact-model-b"
 
     def test_import_year_ignores_mismatch_when_flag_set_and_db_empty(self, tmp_path):
-        """_import_year proceeds and returns mismatch_was_ignored=True when flag is set and local DB is empty."""
+        """_import_year proceeds without raising when ignore flag is set and local DB is empty."""
         set_test_db(tmp_path / "target.db")
 
         paper_db_path = tmp_path / "papers-2024.db"
@@ -1782,10 +1782,39 @@ class TestCLICommands:
                     ignore_embedding_model_mismatch=True,
                 )
 
-        assert result["mismatch_was_ignored"] is True
+        assert result["paper_count"] == 0
+        assert result["embedding_count"] == 0
+
+    def test_import_year_replaces_artifact_model_when_mismatch_ignored(self, tmp_path):
+        """_import_year rewrites artifact DB model when ignore flag is set so downstream checks pass."""
+        set_test_db(tmp_path / "target.db")
+
+        paper_db_path = tmp_path / "papers-2024.db"
+        self._make_artifact_paper_db(paper_db_path, "artifact-model-b")
+        embeddings_path = tmp_path / "embeddings-2024.json"
+        embeddings_path.write_text(json.dumps({"ids": [], "documents": [], "metadatas": [], "embeddings": []}))
+
+        with patch("oras.client.OrasClient"):
+            client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
+
+        with patch("abstracts_explorer.database.DatabaseManager.import_papers_from_sqlite", return_value=0):
+            with patch("abstracts_explorer.embeddings.EmbeddingsManager.import_embeddings", return_value=0):
+                client._import_year(
+                    "neurips",
+                    2024,
+                    paper_db_path,
+                    embeddings_path,
+                    lambda m: None,
+                    embedding_model="configured-model-a",
+                    ignore_embedding_model_mismatch=True,
+                )
+
+        # Verify the artifact DB was patched
+        updated_model = RegistryClient._read_artifact_embedding_model(paper_db_path)
+        assert updated_model == "configured-model-a"
 
     def test_import_year_no_mismatch_when_models_match(self, tmp_path):
-        """_import_year returns mismatch_was_ignored=False when models match."""
+        """_import_year succeeds when models match."""
         set_test_db(tmp_path / "target.db")
 
         paper_db_path = tmp_path / "papers-2024.db"
@@ -1807,7 +1836,78 @@ class TestCLICommands:
                     embedding_model="same-model",
                 )
 
-        assert result["mismatch_was_ignored"] is False
+        assert result["paper_count"] == 0
+        assert result["embedding_count"] == 0
+
+    # ------------------------------------------------------------------
+    # _check_embedding_model / _read_artifact_embedding_model /
+    # _replace_artifact_embedding_model tests
+    # ------------------------------------------------------------------
+
+    def test_read_artifact_embedding_model(self, tmp_path):
+        """_read_artifact_embedding_model returns the model from the artifact DB."""
+        paper_db = tmp_path / "papers.db"
+        self._make_artifact_paper_db(paper_db, "test-model")
+
+        assert RegistryClient._read_artifact_embedding_model(paper_db) == "test-model"
+
+    def test_read_artifact_embedding_model_legacy_db(self, tmp_path):
+        """_read_artifact_embedding_model returns None for a legacy DB without embeddings_metadata."""
+        paper_db = tmp_path / "papers.db"
+        import sqlite3
+
+        with sqlite3.connect(str(paper_db)) as conn:
+            conn.execute("CREATE TABLE dummy (id INTEGER)")
+
+        assert RegistryClient._read_artifact_embedding_model(paper_db) is None
+
+    def test_replace_artifact_embedding_model(self, tmp_path):
+        """_replace_artifact_embedding_model overwrites the model in the artifact DB."""
+        paper_db = tmp_path / "papers.db"
+        self._make_artifact_paper_db(paper_db, "old-model")
+
+        RegistryClient._replace_artifact_embedding_model(paper_db, "new-model")
+
+        assert RegistryClient._read_artifact_embedding_model(paper_db) == "new-model"
+
+    def test_check_embedding_model_raises_on_mismatch(self, tmp_path):
+        """_check_embedding_model raises EmbeddingModelMismatchError when models differ."""
+        paper_db = tmp_path / "papers.db"
+        self._make_artifact_paper_db(paper_db, "artifact-model")
+
+        with pytest.raises(EmbeddingModelMismatchError) as exc_info:
+            RegistryClient._check_embedding_model(paper_db, "config-model", False, lambda m: None)
+
+        assert exc_info.value.local_model == "config-model"
+        assert exc_info.value.remote_model == "artifact-model"
+
+    def test_check_embedding_model_replaces_when_ignored(self, tmp_path):
+        """_check_embedding_model replaces artifact model when ignore flag is set."""
+        paper_db = tmp_path / "papers.db"
+        self._make_artifact_paper_db(paper_db, "artifact-model")
+
+        RegistryClient._check_embedding_model(paper_db, "config-model", True, lambda m: None)
+
+        assert RegistryClient._read_artifact_embedding_model(paper_db) == "config-model"
+
+    def test_check_embedding_model_no_op_when_models_match(self, tmp_path):
+        """_check_embedding_model does nothing when models match."""
+        paper_db = tmp_path / "papers.db"
+        self._make_artifact_paper_db(paper_db, "same-model")
+
+        # Should not raise
+        RegistryClient._check_embedding_model(paper_db, "same-model", False, lambda m: None)
+
+    def test_check_embedding_model_no_op_for_legacy(self, tmp_path):
+        """_check_embedding_model does nothing for legacy artifacts without metadata."""
+        paper_db = tmp_path / "papers.db"
+        import sqlite3
+
+        with sqlite3.connect(str(paper_db)) as conn:
+            conn.execute("CREATE TABLE dummy (id INTEGER)")
+
+        # Should not raise
+        RegistryClient._check_embedding_model(paper_db, "config-model", False, lambda m: None)
 
     def test_download_raises_mismatch_when_db_empty_and_no_manifest_model(self, tmp_path):
         """download() raises EmbeddingModelMismatchError from artifact paper DB when manifest has no model label."""
@@ -1837,133 +1937,8 @@ class TestCLICommands:
         assert exc_info.value.local_model == "configured-model-a"
         assert exc_info.value.remote_model == "artifact-model-b"
 
-    def test_download_mismatch_with_matching_config_prompts_clear(self, tmp_path, capsys, monkeypatch):
-        """Download offers to clear local data when configured model matches remote model."""
-        from abstracts_explorer.cli import registry_download_command
-
-        args = argparse.Namespace(
-            repository="ghcr.io/thawn/abstracts-data",
-            token="test-token",
-            conference="neurips",
-            year=2024,
-            tag=None,
-            yes=False,
-            embedding_model="model-b",
-        )
-
-        mismatch = EmbeddingModelMismatchError("model-a", "model-b")
-        success_summary = {
-            "tag": "neurips-2024_model-b",
-            "conference": "neurips",
-            "years": [2024],
-            "paper_count": 10,
-            "embedding_count": 10,
-            "metadata": {},
-        }
-
-        # Simulate user confirming the clear
-        monkeypatch.setattr("builtins.input", lambda _: "y")
-
-        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
-            mock_instance = MockClient.return_value
-            mock_instance.download.side_effect = [mismatch, success_summary]
-
-            with patch("abstracts_explorer.registry.RegistryClient.clear_local_embedding_data") as mock_clear:
-                result = registry_download_command(args)
-
-        mock_clear.assert_called_once()
-        assert result == 0
-
-    def test_download_mismatch_with_matching_config_yes_flag(self, tmp_path, capsys):
-        """Download clears local data without prompting when --yes is set."""
-        from abstracts_explorer.cli import registry_download_command
-
-        args = argparse.Namespace(
-            repository="ghcr.io/thawn/abstracts-data",
-            token="test-token",
-            conference="neurips",
-            year=2024,
-            tag=None,
-            yes=True,
-            embedding_model="model-b",
-        )
-
-        mismatch = EmbeddingModelMismatchError("model-a", "model-b")
-        success_summary = {
-            "tag": "neurips-2024_model-b",
-            "conference": "neurips",
-            "years": [2024],
-            "paper_count": 5,
-            "embedding_count": 5,
-            "metadata": {},
-        }
-
-        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
-            mock_instance = MockClient.return_value
-            mock_instance.download.side_effect = [mismatch, success_summary]
-
-            with patch("abstracts_explorer.registry.RegistryClient.clear_local_embedding_data") as mock_clear:
-                result = registry_download_command(args)
-
-        mock_clear.assert_called_once()
-        assert result == 0
-
-    def test_download_mismatch_user_declines_clear(self, tmp_path, capsys, monkeypatch):
-        """Download aborts when user declines to clear local data."""
-        from abstracts_explorer.cli import registry_download_command
-
-        args = argparse.Namespace(
-            repository="ghcr.io/thawn/abstracts-data",
-            token="test-token",
-            conference="neurips",
-            year=2024,
-            tag=None,
-            yes=False,
-            embedding_model="model-b",
-        )
-
-        mismatch = EmbeddingModelMismatchError("model-a", "model-b")
-
-        monkeypatch.setattr("builtins.input", lambda _: "n")
-
-        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
-            mock_instance = MockClient.return_value
-            mock_instance.download.side_effect = mismatch
-
-            with patch("abstracts_explorer.registry.RegistryClient.clear_local_embedding_data") as mock_clear:
-                result = registry_download_command(args)
-
-        mock_clear.assert_not_called()
-        assert result == 1
-
-    def test_download_mismatch_config_does_not_match_remote(self, tmp_path, capsys):
-        """Download shows error when configured model doesn't match remote model."""
-        from abstracts_explorer.cli import registry_download_command
-
-        args = argparse.Namespace(
-            repository="ghcr.io/thawn/abstracts-data",
-            token="test-token",
-            conference="neurips",
-            year=2024,
-            tag=None,
-            yes=True,  # skip initial confirmation
-            embedding_model="model-c",  # different from remote "model-b"
-        )
-
-        mismatch = EmbeddingModelMismatchError("model-a", "model-b")
-
-        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
-            mock_instance = MockClient.return_value
-            mock_instance.download.side_effect = mismatch
-
-            with patch("abstracts_explorer.registry.RegistryClient.clear_local_embedding_data") as mock_clear:
-                result = registry_download_command(args)
-
-        mock_clear.assert_not_called()
-        assert result == 1
-
-    def test_download_mismatch_config_does_not_match_remote_suggests_ignore_flag(self, tmp_path, capsys):
-        """Download error message mentions --ignore-embedding-model-mismatch when configured model differs."""
+    def test_download_mismatch_single_conference_shows_error(self, tmp_path, capsys):
+        """Download shows error and suggests --ignore-embedding-model-mismatch for single conference mismatch."""
         from abstracts_explorer.cli import registry_download_command
 
         args = argparse.Namespace(
@@ -1986,6 +1961,7 @@ class TestCLICommands:
 
         captured = capsys.readouterr()
         assert result == 1
+        assert "model-b" in captured.err
         assert "--ignore-embedding-model-mismatch" in captured.err
 
     def test_download_ignore_embedding_model_mismatch_proceeds(self, tmp_path, capsys):
@@ -2228,8 +2204,8 @@ class TestCLICommands:
         assert exc_info.value.local_model == "configured-model-a"
         assert exc_info.value.remote_model == "artifact-model-b"
 
-    def test_download_ignore_mismatch_updates_embedding_model(self, tmp_path):
-        """download() updates local embedding model metadata when ignore_embedding_model_mismatch=True."""
+    def test_download_ignore_mismatch_does_not_raise(self, tmp_path):
+        """download() does not raise when ignore_embedding_model_mismatch=True and manifest model differs."""
         set_test_db(tmp_path / "target.db")
 
         paper_db_path = tmp_path / "papers-2024.db"
@@ -2245,16 +2221,15 @@ class TestCLICommands:
         with patch.object(client, "_get_manifest_embedding_model", return_value="artifact-model-b"):
             with patch.object(client._client, "pull", return_value=pulled_files):
                 with patch.object(client, "_import_year", return_value={"paper_count": 0, "embedding_count": 0}):
-                    with patch("abstracts_explorer.database.DatabaseManager.set_embedding_model") as mock_set_model:
-                        client.download(
-                            conference="neurips",
-                            year=2024,
-                            tag="neurips-2024_model-a",
-                            embedding_model="configured-model-a",
-                            ignore_embedding_model_mismatch=True,
-                        )
+                    result = client.download(
+                        conference="neurips",
+                        year=2024,
+                        tag="neurips-2024_model-a",
+                        embedding_model="configured-model-a",
+                        ignore_embedding_model_mismatch=True,
+                    )
 
-        mock_set_model.assert_called_once_with("configured-model-a")
+        assert result["paper_count"] == 0
 
     def test_download_no_mismatch_check_when_no_manifest_model(self, tmp_path):
         """download() skips model check when manifest has no embedding model label (legacy artifact)."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -175,6 +175,44 @@ class TestBuildTag:
         assert tag == f"neurips-2024_model-a_{expected_version}"
 
 
+
+# ---------------------------------------------------------------------------
+# Tests: _is_conference_level_tag
+# ---------------------------------------------------------------------------
+
+
+class TestIsConferenceLevelTag:
+    """Tests for RegistryClient._is_conference_level_tag."""
+
+    def test_conference_only_tag(self):
+        """Conference-only tag (no year) is a conference-level tag."""
+        assert RegistryClient._is_conference_level_tag("neurips_model-a_1.0.0") is True
+
+    def test_year_specific_tag(self):
+        """Tag with a 4-digit year suffix is NOT a conference-level tag."""
+        assert RegistryClient._is_conference_level_tag("neurips-2024_model-a_1.0.0") is False
+
+    def test_year_specific_tag_other_year(self):
+        """Any 4-digit year suffix marks a year-specific tag."""
+        assert RegistryClient._is_conference_level_tag("chi-2026_model_0.4.1") is False
+
+    def test_conference_with_hyphen_no_year(self):
+        """Conference name containing a hyphen but no year is still conference-level."""
+        assert RegistryClient._is_conference_level_tag("ml4ps-workshop_model_0.4.1") is True
+
+    def test_tag_without_underscore(self):
+        """Legacy tag without underscore separator and no year is treated as conference-level."""
+        assert RegistryClient._is_conference_level_tag("neurips") is True
+
+    def test_legacy_tag_with_year_no_underscore(self):
+        """Legacy year-specific tag without underscore is correctly identified."""
+        assert RegistryClient._is_conference_level_tag("neurips-2024") is False
+
+    def test_three_digit_suffix_is_conference_level(self):
+        """A 3-digit numeric suffix does NOT make a tag year-specific."""
+        assert RegistryClient._is_conference_level_tag("neurips-123_model_1.0.0") is True
+
+
 # ---------------------------------------------------------------------------
 # Tests: RegistryClient initialisation
 # ---------------------------------------------------------------------------
@@ -1173,20 +1211,20 @@ class TestUploadDownload:
             client.upload_all()
 
     def test_download_all_conferences(self, tmp_path):
-        """download_all downloads all tags from registry."""
+        """download_all downloads conference-level tags from registry."""
         set_test_db(tmp_path / "target.db")
 
         # Create fake pulled files for each download
         source_db = _populate_test_db(tmp_path / "source.db")
 
-        # For iclr-2024 tag (alphabetically first)
+        # For iclr tag (alphabetically first)
         papers_i = tmp_path / "pull_i" / "papers-2024.db"
         papers_i.parent.mkdir()
         source_db.export_papers_to_sqlite(papers_i, "iclr", 2024)
         emb_i = tmp_path / "pull_i" / "embeddings-2024.json"
         emb_i.write_text(json.dumps({"ids": ["b"], "documents": ["d"], "metadatas": [{}], "embeddings": [[0.2]]}))
 
-        # For neurips-2024 tag
+        # For neurips tag
         papers_n = tmp_path / "pull_n" / "papers-2024.db"
         papers_n.parent.mkdir()
         source_db.export_papers_to_sqlite(papers_n, "neurips", 2024)
@@ -1202,8 +1240,8 @@ class TestUploadDownload:
         with patch("oras.client.OrasClient") as MockOras:
             mock_oras = MockOras.return_value
             mock_oras.get_tags.return_value = [
-                "neurips-2024_text-embedding-ada-002",
-                "iclr-2024_text-embedding-ada-002",
+                "neurips_text-embedding-ada-002",
+                "iclr_text-embedding-ada-002",
             ]
             # get_manifest returns annotations for each tag
             mock_oras.get_manifest.side_effect = [
@@ -1222,8 +1260,8 @@ class TestUploadDownload:
             ]
             # Side effect returns files in order of download (sorted tags: iclr..., neurips...)
             mock_oras.pull.side_effect = [
-                [str(papers_i), str(emb_i)],  # first call: iclr-2024
-                [str(papers_n), str(emb_n)],  # second call: neurips-2024
+                [str(papers_i), str(emb_i)],  # first call: iclr
+                [str(papers_n), str(emb_n)],  # second call: neurips
             ]
             client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
 
@@ -1232,6 +1270,49 @@ class TestUploadDownload:
 
         assert len(summaries) == 2
         assert mock_em.import_embeddings.call_count == 2
+
+    def test_download_all_skips_year_specific_tags(self, tmp_path):
+        """download_all skips year-specific tags and only downloads conference-level tags."""
+        set_test_db(tmp_path / "target.db")
+
+        with patch("oras.client.OrasClient") as MockOras:
+            mock_oras = MockOras.return_value
+            # Mix of year-specific and conference-level tags
+            mock_oras.get_tags.return_value = [
+                "neurips-2024_model-a_0.4.1",
+                "neurips-2025_model-a_0.4.1",
+                "neurips_model-a_0.4.1",
+                "iclr-2024_model-a_0.4.1",
+                "iclr_model-a_0.4.1",
+            ]
+            client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
+
+        summary = {"conference": "neurips", "paper_count": 0, "embedding_count": 0, "years": []}
+        with patch.object(client, "get_artifact_info", return_value={"annotations": {}}):
+            with patch.object(client, "download", return_value=summary) as mock_dl:
+                client.download_all()
+
+        # Only 2 conference-level tags should be downloaded, not the 3 year-specific ones
+        assert mock_dl.call_count == 2
+        downloaded_tags = [call.kwargs["tag"] for call in mock_dl.call_args_list]
+        assert "neurips_model-a_0.4.1" in downloaded_tags
+        assert "iclr_model-a_0.4.1" in downloaded_tags
+        assert "neurips-2024_model-a_0.4.1" not in downloaded_tags
+        assert "neurips-2025_model-a_0.4.1" not in downloaded_tags
+        assert "iclr-2024_model-a_0.4.1" not in downloaded_tags
+
+    def test_download_all_only_year_tags_raises(self, tmp_path):
+        """download_all raises RegistryError when only year-specific tags exist."""
+        with patch("oras.client.OrasClient") as MockOras:
+            mock_oras = MockOras.return_value
+            mock_oras.get_tags.return_value = [
+                "neurips-2024_model-a_0.4.1",
+                "iclr-2024_model-a_0.4.1",
+            ]
+            client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
+
+        with pytest.raises(RegistryError, match="No conference-level tags"):
+            client.download_all()
 
     def test_download_all_no_tags(self, tmp_path):
         """download_all raises RegistryError when no tags exist."""
@@ -1250,8 +1331,8 @@ class TestUploadDownload:
         with patch("oras.client.OrasClient") as MockOras:
             mock_oras = MockOras.return_value
             mock_oras.get_tags.return_value = [
-                "neurips-2024_model-a",
-                "iclr-2024_model-a",
+                "neurips_model-a",
+                "iclr_model-a",
             ]
             client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
 
@@ -1270,7 +1351,7 @@ class TestUploadDownload:
 
         with patch("oras.client.OrasClient") as MockOras:
             mock_oras = MockOras.return_value
-            mock_oras.get_tags.return_value = ["neurips-2024_model-a"]
+            mock_oras.get_tags.return_value = ["neurips_model-a"]
             client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
 
         summary = {"conference": "neurips", "paper_count": 0, "embedding_count": 0}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -175,7 +175,6 @@ class TestBuildTag:
         assert tag == f"neurips-2024_model-a_{expected_version}"
 
 
-
 # ---------------------------------------------------------------------------
 # Tests: _is_conference_level_tag
 # ---------------------------------------------------------------------------
@@ -211,6 +210,15 @@ class TestIsConferenceLevelTag:
     def test_three_digit_suffix_is_conference_level(self):
         """A 3-digit numeric suffix does NOT make a tag year-specific."""
         assert RegistryClient._is_conference_level_tag("neurips-123_model_1.0.0") is True
+
+    def test_five_digit_suffix_is_conference_level(self):
+        """A 5-digit numeric suffix does NOT make a tag year-specific."""
+        assert RegistryClient._is_conference_level_tag("neurips-12345_model_1.0.0") is True
+
+    def test_year_out_of_range_is_conference_level(self):
+        """A 4-digit number outside 2000-2099 does NOT make a tag year-specific."""
+        assert RegistryClient._is_conference_level_tag("neurips-9999_model_1.0.0") is True
+        assert RegistryClient._is_conference_level_tag("neurips-1999_model_1.0.0") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1242,6 +1242,44 @@ class TestUploadDownload:
         with pytest.raises(RegistryError, match="No tags found"):
             client.download_all()
 
+    def test_download_all_forwards_ignore_mismatch_flag(self, tmp_path):
+        """download_all forwards ignore_embedding_model_mismatch to each download() call."""
+        set_test_db(tmp_path / "target.db")
+
+        with patch("oras.client.OrasClient") as MockOras:
+            mock_oras = MockOras.return_value
+            mock_oras.get_tags.return_value = [
+                "neurips-2024_model-a",
+                "iclr-2024_model-a",
+            ]
+            client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
+
+        summary = {"conference": "neurips", "paper_count": 0, "embedding_count": 0}
+        with patch.object(client, "get_artifact_info", return_value={"annotations": {}}):
+            with patch.object(client, "download", return_value=summary) as mock_dl:
+                client.download_all(ignore_embedding_model_mismatch=True)
+
+        assert mock_dl.call_count == 2
+        for call in mock_dl.call_args_list:
+            assert call.kwargs["ignore_embedding_model_mismatch"] is True
+
+    def test_download_all_default_ignore_mismatch_false(self, tmp_path):
+        """download_all passes ignore_embedding_model_mismatch=False by default."""
+        set_test_db(tmp_path / "target.db")
+
+        with patch("oras.client.OrasClient") as MockOras:
+            mock_oras = MockOras.return_value
+            mock_oras.get_tags.return_value = ["neurips-2024_model-a"]
+            client = RegistryClient("ghcr.io/thawn/abstracts-data", token="token")
+
+        summary = {"conference": "neurips", "paper_count": 0, "embedding_count": 0}
+        with patch.object(client, "get_artifact_info", return_value={"annotations": {}}):
+            with patch.object(client, "download", return_value=summary) as mock_dl:
+                client.download_all()
+
+        mock_dl.assert_called_once()
+        assert mock_dl.call_args.kwargs["ignore_embedding_model_mismatch"] is False
+
     def test_cli_upload_all_conferences(self, tmp_path, capsys, monkeypatch):
         """CLI upload with --conference all invokes upload_all."""
         from abstracts_explorer.cli import registry_upload_command
@@ -1292,6 +1330,33 @@ class TestUploadDownload:
         captured = capsys.readouterr()
         assert "Download complete" in captured.out
         assert "2 artifact(s)" in captured.out
+
+    def test_cli_download_all_embedding_model_mismatch(self, capsys):
+        """CLI download --conference all returns 1 and prints guidance on EmbeddingModelMismatchError."""
+        from abstracts_explorer.cli import registry_download_command
+
+        args = argparse.Namespace(
+            repository="ghcr.io/thawn/abstracts-data",
+            token="test-token",
+            conference="all",
+            year=None,
+            tag=None,
+            yes=True,
+            embedding_model="local-model",
+            ignore_embedding_model_mismatch=False,
+        )
+
+        mismatch = EmbeddingModelMismatchError("local-model", "remote-model")
+        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
+            mock_instance = MockClient.return_value
+            mock_instance.download_all.side_effect = mismatch
+
+            result = registry_download_command(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "remote-model" in captured.err
+        assert "--ignore-embedding-model-mismatch" in captured.err
 
 
 # ---------------------------------------------------------------------------
@@ -1599,6 +1664,32 @@ class TestCLICommands:
 
         assert result == 0
         mock_instance.download_all.assert_called_once()
+
+    def test_registry_download_all_ignore_mismatch_flag_forwarded(self, capsys):
+        """CLI --ignore-embedding-model-mismatch flag is forwarded to download_all() when --conference all."""
+        from abstracts_explorer.cli import registry_download_command
+
+        args = argparse.Namespace(
+            repository="ghcr.io/thawn/abstracts-data",
+            token="test-token",
+            conference="all",
+            year=None,
+            tag=None,
+            yes=True,
+            embedding_model=None,
+            ignore_embedding_model_mismatch=True,
+        )
+
+        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
+            mock_instance = MockClient.return_value
+            mock_instance.download_all.return_value = []
+
+            result = registry_download_command(args)
+
+        assert result == 0
+        mock_instance.download_all.assert_called_once()
+        call_kwargs = mock_instance.download_all.call_args.kwargs
+        assert call_kwargs["ignore_embedding_model_mismatch"] is True
 
     def test_embedding_model_mismatch_error_attributes(self):
         """EmbeddingModelMismatchError carries local_model and remote_model."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -7,6 +7,7 @@ EmbeddingsManager export/import methods, and CLI command integration.
 
 import argparse
 import json
+import sqlite3
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -1854,7 +1855,6 @@ class TestCLICommands:
     def test_read_artifact_embedding_model_legacy_db(self, tmp_path):
         """_read_artifact_embedding_model returns None for a legacy DB without embeddings_metadata."""
         paper_db = tmp_path / "papers.db"
-        import sqlite3
 
         with sqlite3.connect(str(paper_db)) as conn:
             conn.execute("CREATE TABLE dummy (id INTEGER)")
@@ -1901,7 +1901,6 @@ class TestCLICommands:
     def test_check_embedding_model_no_op_for_legacy(self, tmp_path):
         """_check_embedding_model does nothing for legacy artifacts without metadata."""
         paper_db = tmp_path / "papers.db"
-        import sqlite3
 
         with sqlite3.connect(str(paper_db)) as conn:
             conn.execute("CREATE TABLE dummy (id INTEGER)")

--- a/tests/test_registry_integration.py
+++ b/tests/test_registry_integration.py
@@ -810,39 +810,3 @@ class TestCLIRegistryDispatch:
 
         assert result == 0
         mock_instance.upload_all.assert_called_once()
-
-    def test_download_command_mismatch_clear_and_retry_with_yes(self, tmp_path, capsys):
-        """download command auto-clears and retries when --yes and configured model matches remote."""
-        import argparse
-
-        from abstracts_explorer.cli import registry_download_command
-
-        mismatch = EmbeddingModelMismatchError("old-model", "new-model")
-        success = {
-            "tag": "neurips-2024_new-model",
-            "conference": "neurips",
-            "years": [2024],
-            "paper_count": 3,
-            "embedding_count": 3,
-            "metadata": {},
-        }
-
-        args = argparse.Namespace(
-            repository="ghcr.io/thawn/abstracts-data",
-            token="test-token",
-            conference="neurips",
-            year=2024,
-            tag=None,
-            yes=True,
-            embedding_model="new-model",  # matches remote model in mismatch error
-        )
-
-        with patch("abstracts_explorer.registry.RegistryClient") as MockClient:
-            mock_instance = MockClient.return_value
-            mock_instance.download.side_effect = [mismatch, success]
-
-            with patch("abstracts_explorer.registry.RegistryClient.clear_local_embedding_data") as mock_clear:
-                result = registry_download_command(args)
-
-        mock_clear.assert_called_once()
-        assert result == 0


### PR DESCRIPTION
## Fix: download_all skips year-specific tags to prevent double import

**Problem:** When uploading, each conference creates both per-year tags (`chi-2026_model_0.4.1`) and a combined conference-level tag (`chi_model_0.4.1`). `download_all()` was downloading ALL tags — causing each year's data to be imported twice.

**Solution:**
- [x] Add `_is_conference_level_tag()` static method: returns `True` when the base (before first `_`) does NOT end with a plausible 4-digit year (`-YYYY`, 2000-2099)
- [x] Filter the tag list in `download_all()` to only include conference-level tags
- [x] Raise `RegistryError("No conference-level tags found")` when tags exist but none are conference-level
- [x] Add 9 unit tests for `_is_conference_level_tag()` (including 5-digit suffix and out-of-range year tests)
- [x] Update existing tests that mocked year-specific tags to use conference-level tags
- [x] Add `test_download_all_skips_year_specific_tags` to verify the filtering
- [x] Add `test_download_all_only_year_tags_raises` for the new error case
- [x] All 121 tests pass