### PR TITLE
fix-conference-level-detection

### DIFF
--- a/docs/chat_example.md
+++ b/docs/chat_example.md
@@ -1,0 +1,100 @@
+# Chat Example: Uncertainty Quantification in Conference Abstracts
+
+Here is an example of a conversation with the AI research assistant about uncertainty quantification in conference abstracts. The assistant provides insights based on analysis of papers from NeurIPS, ICLR, and ICML, highlighting trends, key papers, and the importance of UQ in machine learning research.
+
+**Assistant:**
+Hello! I'm your AI research assistant. Ask me anything about conference abstracts, and I'll help you find relevant research and insights.
+
+**User:**
+how important is uncertainty quantification?
+
+**Assistant:**
+Based on my analysis, uncertainty quantification (UQ) is a moderately important and growing research topic, especially at top-tier machine learning conferences like NeurIPS, ICLR, and ICML:
+Key Findings:
+
+* Relevance Score:
+  * NeurIPS: 6.2/100 (311 papers out of 5,000) — highest among the three.
+  * ICLR: 3.5/100 (174 papers).
+  * ICML: 3.7/100 (185 papers).
+
+* Trends Over Time (NeurIPS):
+  Steady increase from 40 papers in 2020 to 60 in 2022, followed by slight fluctuations but remained strong (e.g., 58 in 2025).
+
+* ICLR & ICML Trends:
+  Notably, ICLR saw a sharp rise from 10 papers in 2020 to 45 in 2026 (note: likely includes early 2026 submissions), indicating increasing interest.
+
+* Clusters:
+        While UQ doesn’t dominate any top cluster, its consistent presence across multiple years and venues signals sustained interest.
+
+* Closest Papers:
+        Recent work includes methods like Single Model Uncertainty Estimation via Stochastic Data Centering, SDE-Net, and Distribution-Free Uncertainty Quantification, highlighting methodological innovation.
+
+Conclusion:
+
+Uncertainty quantification is a moderately important and rising topic, with particular emphasis at NeurIPS. Its relevance spans foundational methods and applications in safety-critical domains (e.g., healthcare, autonomous systems), where reliable uncertainty estimates are crucial for trustworthy AI.
+
+Would you like me to identify specific papers or clusters related to UQ in more detail?
+
+**User:**
+show me the top papers at the three conferences
+
+**Assistant:**
+Here are the top papers on uncertainty quantification (UQ) at the three major machine learning conferences, based on semantic relevance and impact:
+
+🔝 NeurIPS
+
+    Single Model Uncertainty Estimation via Stochastic Data Centering (2022)
+    NeurIPS Paper
+    Focuses on uncertainty estimation for deep neural networks using a single model.
+
+    Nonparametric Uncertainty Quantification for Single Deterministic Neural Network (2022)
+    NeurIPS Paper
+    Proposes a fast, scalable method for uncertainty quantification without ensembling.
+
+    PICProp: Physics-Informed Confidence Propagation for Uncertainty Quantification (2023)
+    NeurIPS Paper
+    Integrates physics-informed priors to improve confidence estimation in deep learning.
+
+    Asymptotic Theory of Geometric and Adaptive k-Means Clustering (2025)
+    NeurIPS Paper
+    While primarily about clustering, it contributes to UQ via asymptotic uncertainty analysis.
+
+🔝 ICLR
+
+    ValUES: A Framework for Systematic Validation of Uncertainty Estimation in Semantic Segmentation (2024)
+    ICLR Paper
+    Introduces a standardized framework to evaluate uncertainty methods in segmentation tasks.
+
+    On the Sample Complexity of Lipschitz Constant Estimation (2024)
+    ICLR Paper
+    Provides theoretical insights into uncertainty bounds via Lipschitz continuity.
+
+    Pathologies of Predictive Diversity in Deep Ensembles (2024)
+    ICLR Paper
+    Analyzes limitations of ensemble-based UQ methods and proposes improvements.
+
+🔝 ICML
+
+    SDE-Net: Equipping Deep Neural Networks with Uncertainty Estimates (2020)
+    ICML Paper
+    Introduces stochastic differential equations to embed uncertainty into deep models.
+
+    Image-to-Image Regression with Distribution-Free Uncertainty Quantification and Applications in Imaging (2022)
+    ICML Paper
+    Proposes a distribution-free UQ method for image regression tasks.
+
+    Using AI Uncertainty Quantification to Improve Human Decision-Making (2024)
+    ICML Paper
+    Explores how UQ can support human users in high-stakes decisions.
+
+    Online Algorithms with Uncertainty-Quantified Predictions (2024)
+    ICML Paper
+    Integrates UQ into algorithmic prediction frameworks.
+
+📊 Observations:
+
+    2024–2025 saw a surge in UQ-related papers, especially at ICLR and ICML.
+    Methodologically, UQ is increasingly moving toward single-model estimation, distribution-free bounds, and physics-informed priors.
+    Applications are growing in semantic segmentation, imaging, and human-in-the-loop systems.
+
+Would you like me to provide direct links (e.g., arXiv or official versions) for any of these papers?

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -351,7 +351,7 @@ class RegistryClient:
             return True
         suffix = parts[1]
         # A year suffix is exactly 4 digits in a plausible conference year range.
-        return not (suffix.isdigit() and len(suffix) == 4 and 2000 <= int(suffix) <= 2099)
+        return not (suffix.isdigit() and len(suffix) == 4)
 
     def _find_best_matching_tag(self, tag: str) -> str:
         """

--- a/src/abstracts_explorer/registry.py
+++ b/src/abstracts_explorer/registry.py
@@ -350,7 +350,7 @@ class RegistryClient:
         if len(parts) != 2:
             return True
         suffix = parts[1]
-        # A year suffix is exactly 4 digits in a plausible conference year range.
+        # A year suffix is exactly 4 digits.
         return not (suffix.isdigit() and len(suffix) == 4)
 
     def _find_best_matching_tag(self, tag: str) -> str:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -215,11 +215,6 @@ class TestIsConferenceLevelTag:
         """A 5-digit numeric suffix does NOT make a tag year-specific."""
         assert RegistryClient._is_conference_level_tag("neurips-12345_model_1.0.0") is True
 
-    def test_year_out_of_range_is_conference_level(self):
-        """A 4-digit number outside 2000-2099 does NOT make a tag year-specific."""
-        assert RegistryClient._is_conference_level_tag("neurips-9999_model_1.0.0") is True
-        assert RegistryClient._is_conference_level_tag("neurips-1999_model_1.0.0") is True
-
 
 # ---------------------------------------------------------------------------
 # Tests: RegistryClient initialisation


### PR DESCRIPTION
update year suffix validation to remove too restrictive integer range check