### PR TITLE
chore: update deploy-pages action to version 5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -146,4 +146,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@v5


### PR DESCRIPTION
v4 causes a warning about deprecated node version 20 being removed from runners in June 2026