### PR TITLE
chore: update actions to latest versions

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
       with:
         version: "latest"
         enable-cache: ${{ inputs.uv-cache }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -23,13 +23,13 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: actions/setup-python@v8
       with:
         version: "latest"
         enable-cache: ${{ inputs.uv-cache }}
 
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: actions/setup-python@v8
+      uses: astral-sh/setup-uv@v8
       with:
         version: "latest"
         enable-cache: ${{ inputs.uv-cache }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Needed for hatch-vcs to determine version
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
@@ -129,7 +129,7 @@ jobs:
 
             - name: Upload artifact
               if: github.event_name != 'pull_request'
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v4
               with:
                   path: /tmp/site
 

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Setup Abstracts Explorer Environment
               uses: ./.github/actions/setup-environment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: actions/setup-python@v8
+              uses: astral-sh/setup-uv@v8
               with:
                   version: "latest"
                   enable-cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,16 +24,16 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v4
+              uses: actions/setup-python@v8
               with:
                   version: "latest"
                   enable-cache: true
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
               with:
                   version: "latest"
                   enable-cache: true

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -43,18 +43,18 @@ jobs:
             contents: read
         
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v4
+              uses: actions/setup-python@v8
               with:
                   version: "latest"
                   enable-cache: true
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -48,7 +48,7 @@ jobs:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
               with:
                   version: "latest"
                   enable-cache: true

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -48,7 +48,7 @@ jobs:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
             - name: Install uv
-              uses: actions/setup-python@v8
+              uses: astral-sh/setup-uv@v8
               with:
                   version: "latest"
                   enable-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,18 +35,18 @@ jobs:
                 python-version: ["3.11", "3.12", "3.13"]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v4
+              uses: actions/setup-python@v8
               with:
                   version: "latest"
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
               with:
                   version: "latest"
                   enable-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
                   fetch-depth: 0 # Needed for hatch-vcs to determine version
 
             - name: Install uv
-              uses: actions/setup-python@v8
+              uses: astral-sh/setup-uv@v8
               with:
                   version: "latest"
                   enable-cache: true


### PR DESCRIPTION
Updated action version of actions that still use node.js 20 because according to GitHub, actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.