### PR TITLE
Modify health check command in abstracts-chromadb.container

### DIFF
--- a/systemd/user/abstracts-chromadb.container
+++ b/systemd/user/abstracts-chromadb.container
@@ -13,7 +13,8 @@ Volume=abstracts-chromadb-data.volume:/data
 Environment=IS_PERSISTENT=TRUE
 Environment=ANONYMIZED_TELEMETRY=FALSE
 
-HealthCmd=curl -sf http://localhost:8000/api/v1/heartbeat
+# the health check is using apt-helper until curl becomes available - see https://github.com/chroma-core/chroma/pull/6856 . Then we can switch to the recommended command in the chromadb docs: curl -sf http://localhost:8000/api/v2/heartbeat
+HealthCmd=/usr/lib/apt/apt-helper download-file http://localhost:8000/api/v2/heartbeat /tmp/health
 HealthInterval=10s
 HealthTimeout=5s
 HealthRetries=5


### PR DESCRIPTION
Updated health check command to use apt-helper temporarily until curl is available.