### PR TITLE
Add graph-based paper recommendations with PageRank

### DIFF
--- a/src/abstracts_explorer/cli.py
+++ b/src/abstracts_explorer/cli.py
@@ -221,6 +221,7 @@ def create_embeddings_command(args: argparse.Namespace) -> int:
 
     # Resolve conference name once to canonical form
     conference = _resolve_conference_arg(getattr(args, "conference", None))
+    args.conference = conference
 
     # Build combined WHERE clause from --conference, --year, and --where
     where_clause = _build_embeddings_where_clause(args)

--- a/src/abstracts_explorer/recommendations.py
+++ b/src/abstracts_explorer/recommendations.py
@@ -1,0 +1,591 @@
+"""
+Graph-based paper recommendations for Abstracts Explorer.
+
+The recommender builds a small heterogeneous graph from papers, authors,
+keywords, sessions, and embedding-nearest paper links, then runs Personalized
+PageRank from the user's query seeds.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from abstracts_explorer.config import get_config
+from abstracts_explorer.database import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RECOMMENDATION_LIMIT = 50
+DEFAULT_SEMANTIC_NEIGHBORS = 8
+DEFAULT_DAMPING = 0.85
+DEFAULT_MAX_ITER = 60
+DEFAULT_TOLERANCE = 1e-8
+
+
+def _normalise(value: Any) -> str:
+    """Normalise a graph token for stable node IDs."""
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _node(kind: str, value: Any) -> str:
+    return f"{kind}:{_normalise(value)}"
+
+
+def _paper_node(uid: str) -> str:
+    return f"paper:{uid}"
+
+
+def _add_edge(graph: Dict[str, Dict[str, float]], left: str, right: str, weight: float) -> None:
+    if not left or not right or left == right or weight <= 0:
+        return
+    graph[left][right] += weight
+    graph[right][left] += weight
+
+
+def _as_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def _safe_uid(paper: Dict[str, Any]) -> Optional[str]:
+    uid = paper.get("uid")
+    return str(uid) if uid else None
+
+
+def _cosine_similarity_matrix(vectors: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    normalised = vectors / norms
+    return normalised @ normalised.T
+
+
+def _cosine_similarity_to_query(vectors: np.ndarray, query_vector: Sequence[float]) -> np.ndarray:
+    query = np.asarray(query_vector, dtype=float)
+    query_norm = np.linalg.norm(query)
+    if query_norm == 0:
+        return np.zeros(vectors.shape[0], dtype=float)
+    vector_norms = np.linalg.norm(vectors, axis=1)
+    vector_norms[vector_norms == 0] = 1.0
+    return (vectors @ query) / (vector_norms * query_norm)
+
+
+def personalized_pagerank(
+    graph: Dict[str, Dict[str, float]],
+    personalization: Dict[str, float],
+    damping: float = DEFAULT_DAMPING,
+    max_iter: int = DEFAULT_MAX_ITER,
+    tolerance: float = DEFAULT_TOLERANCE,
+) -> Dict[str, float]:
+    """
+    Run weighted Personalized PageRank on an undirected graph.
+
+    Parameters
+    ----------
+    graph
+        Mapping of node -> neighbor -> edge weight.
+    personalization
+        Restart distribution. Nodes missing from the graph are ignored.
+    damping
+        Probability of following graph edges instead of restarting.
+    max_iter
+        Maximum power iterations.
+    tolerance
+        L1 convergence threshold.
+    """
+    nodes = set(graph.keys())
+    for neighbors in graph.values():
+        nodes.update(neighbors.keys())
+    if not nodes:
+        return {}
+
+    restart = {node: max(0.0, personalization.get(node, 0.0)) for node in nodes}
+    restart_total = sum(restart.values())
+    if restart_total <= 0:
+        uniform = 1.0 / len(nodes)
+        restart = {node: uniform for node in nodes}
+    else:
+        restart = {node: value / restart_total for node, value in restart.items()}
+
+    ranks = dict(restart)
+    outgoing_totals = {
+        node: sum(max(0.0, weight) for weight in graph.get(node, {}).values()) for node in nodes
+    }
+
+    for _ in range(max_iter):
+        next_ranks = {node: (1.0 - damping) * restart[node] for node in nodes}
+        dangling_mass = 0.0
+
+        for node, rank in ranks.items():
+            total = outgoing_totals.get(node, 0.0)
+            if total <= 0:
+                dangling_mass += rank
+                continue
+            share = damping * rank / total
+            for neighbor, weight in graph.get(node, {}).items():
+                if weight > 0:
+                    next_ranks[neighbor] += share * weight
+
+        if dangling_mass:
+            for node in nodes:
+                next_ranks[node] += damping * dangling_mass * restart[node]
+
+        delta = sum(abs(next_ranks[node] - ranks.get(node, 0.0)) for node in nodes)
+        ranks = next_ranks
+        if delta < tolerance:
+            break
+
+    return ranks
+
+
+def _get_embeddings_for_papers(embeddings_manager: Any, paper_uids: List[str]) -> Dict[str, List[float]]:
+    if not paper_uids:
+        return {}
+
+    collection_result = embeddings_manager.collection.get(ids=paper_uids, include=["embeddings"])
+    result_ids = collection_result.get("ids", []) or []
+    result_embeddings = collection_result.get("embeddings")
+    if result_embeddings is None:
+        return {}
+
+    return {
+        str(uid): list(embedding)
+        for uid, embedding in zip(result_ids, result_embeddings)
+        if embedding is not None
+    }
+
+
+def _build_seed_papers(
+    database: DatabaseManager,
+    query: str,
+    field_filters: Dict[str, str],
+    remaining_query: str,
+    sessions: Optional[List[str]],
+    years: Optional[List[int]],
+    conferences: Optional[List[str]],
+) -> Tuple[Dict[str, Dict[str, Any]], set[str]]:
+    seed_papers: Dict[str, Dict[str, Any]] = {}
+    exact_seed_uids: set[str] = set()
+
+    if field_filters:
+        matches = database.search_papers(
+            field_filters=field_filters,
+            sessions=sessions,
+            years=years,
+            conferences=conferences,
+            limit=0,
+        )
+        for paper in matches:
+            uid = _safe_uid(paper)
+            if uid:
+                seed_papers[uid] = paper
+                exact_seed_uids.add(uid)
+
+    author_query = remaining_query or query
+    if author_query and "authors" not in field_filters:
+        author_matches = database.search_papers(
+            field_filters={"authors": author_query},
+            sessions=sessions,
+            years=years,
+            conferences=conferences,
+            limit=0,
+        )
+        for paper in author_matches:
+            uid = _safe_uid(paper)
+            if uid:
+                seed_papers[uid] = paper
+                exact_seed_uids.add(uid)
+
+    if remaining_query and not seed_papers:
+        keyword_matches = database.search_papers(
+            keyword=remaining_query,
+            sessions=sessions,
+            years=years,
+            conferences=conferences,
+            limit=25,
+        )
+        for paper in keyword_matches:
+            uid = _safe_uid(paper)
+            if uid:
+                seed_papers[uid] = paper
+                exact_seed_uids.add(uid)
+
+    return seed_papers, exact_seed_uids
+
+
+def _build_graph(
+    papers: Dict[str, Dict[str, Any]],
+    embeddings: Dict[str, List[float]],
+    semantic_neighbors: int = DEFAULT_SEMANTIC_NEIGHBORS,
+) -> Dict[str, Dict[str, float]]:
+    graph: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
+
+    paper_ids = list(papers)
+    for uid in paper_ids:
+        paper = papers[uid]
+        paper_node = _paper_node(uid)
+        graph[paper_node]
+
+        authors = _as_list(paper.get("authors"))
+        for author in authors:
+            _add_edge(graph, paper_node, _node("author", author), 1.25 / max(1, len(authors)))
+
+        keywords = _as_list(paper.get("keywords"))[:8]
+        for keyword in keywords:
+            _add_edge(graph, paper_node, _node("keyword", keyword), 0.55)
+
+        if paper.get("session"):
+            _add_edge(graph, paper_node, _node("session", paper["session"]), 0.45)
+        if paper.get("conference"):
+            _add_edge(graph, paper_node, _node("conference", paper["conference"]), 0.12)
+        if paper.get("year"):
+            _add_edge(graph, paper_node, _node("year", paper["year"]), 0.08)
+
+    embedded_paper_ids = [uid for uid in paper_ids if uid in embeddings]
+    if len(embedded_paper_ids) > 1 and semantic_neighbors > 0:
+        matrix = np.asarray([embeddings[uid] for uid in embedded_paper_ids], dtype=float)
+        similarities = _cosine_similarity_matrix(matrix)
+        np.fill_diagonal(similarities, -math.inf)
+        neighbor_count = min(semantic_neighbors, len(embedded_paper_ids) - 1)
+
+        for i, uid in enumerate(embedded_paper_ids):
+            row = similarities[i]
+            if neighbor_count <= 0:
+                continue
+            if neighbor_count < len(row):
+                neighbor_indices = np.argpartition(row, -neighbor_count)[-neighbor_count:]
+            else:
+                neighbor_indices = np.arange(len(row))
+            for j in neighbor_indices:
+                similarity = float(row[j])
+                if not math.isfinite(similarity) or similarity <= 0:
+                    continue
+                _add_edge(graph, _paper_node(uid), _paper_node(embedded_paper_ids[int(j)]), 0.9 * similarity)
+
+    return graph
+
+
+def _build_personalization(
+    query: str,
+    field_filters: Dict[str, str],
+    seed_papers: Dict[str, Dict[str, Any]],
+    semantic_seed_scores: Dict[str, float],
+) -> Tuple[Dict[str, float], Dict[str, set[str]]]:
+    personalization: Dict[str, float] = defaultdict(float)
+    seed_context = {"authors": set(), "keywords": set(), "sessions": set()}
+
+    for uid, paper in seed_papers.items():
+        personalization[_paper_node(uid)] += 2.0
+        for author in _as_list(paper.get("authors")):
+            norm = _normalise(author)
+            seed_context["authors"].add(norm)
+            personalization[_node("author", author)] += 0.45
+        for keyword in _as_list(paper.get("keywords")):
+            seed_context["keywords"].add(_normalise(keyword))
+        if paper.get("session"):
+            seed_context["sessions"].add(_normalise(paper["session"]))
+
+    if field_filters.get("authors"):
+        personalization[_node("author", field_filters["authors"])] += 3.0
+    if field_filters.get("keywords"):
+        personalization[_node("keyword", field_filters["keywords"])] += 1.2
+    if field_filters.get("session"):
+        personalization[_node("session", field_filters["session"])] += 1.2
+
+    for uid, score in semantic_seed_scores.items():
+        personalization[_paper_node(uid)] += max(0.01, score)
+
+    if query and not personalization:
+        # Defensive fallback; callers normally add semantic seeds first.
+        personalization[_node("query", query)] += 1.0
+
+    return dict(personalization), seed_context
+
+
+def _normalise_scores(scores: Dict[str, float]) -> Dict[str, float]:
+    if not scores:
+        return {}
+    max_score = max(scores.values())
+    if max_score <= 0:
+        return {key: 0.0 for key in scores}
+    return {key: value / max_score for key, value in scores.items()}
+
+
+def _recommendation_reasons(
+    paper: Dict[str, Any],
+    seed_context: Dict[str, set[str]],
+    semantic_score: float,
+    pagerank_score: float,
+) -> List[str]:
+    reasons: List[str] = []
+
+    paper_authors = {_normalise(author) for author in _as_list(paper.get("authors"))}
+    shared_authors = sorted(paper_authors & seed_context.get("authors", set()))
+    if shared_authors:
+        reasons.append("Connected through the searched author/coauthor neighborhood")
+
+    paper_keywords = {_normalise(keyword) for keyword in _as_list(paper.get("keywords"))}
+    shared_keywords = sorted(paper_keywords & seed_context.get("keywords", set()))
+    if shared_keywords:
+        reasons.append(f"Shares keyword: {shared_keywords[0]}")
+
+    session = _normalise(paper.get("session"))
+    if session and session in seed_context.get("sessions", set()):
+        reasons.append("Appears in the same session neighborhood")
+
+    if semantic_score >= 0.55:
+        reasons.append("Abstract is semantically close to the search")
+    if pagerank_score >= 0.5 and not reasons:
+        reasons.append("Central in the Personalized PageRank graph around your search")
+    if not reasons:
+        reasons.append("Graph connection from authors, topics, sessions, or nearby embeddings")
+
+    return reasons[:3]
+
+
+def recommend_papers(
+    database: DatabaseManager,
+    embeddings_manager: Any,
+    query: str,
+    sessions: Optional[List[str]] = None,
+    years: Optional[List[int]] = None,
+    conferences: Optional[List[str]] = None,
+    limit: int = DEFAULT_RECOMMENDATION_LIMIT,
+    unsupported_filters: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Recommend papers with Personalized PageRank over a heterogeneous graph.
+    """
+    field_filters, remaining_query = DatabaseManager.parse_field_filters(query)
+    semantic_query = remaining_query or ("" if field_filters else query)
+
+    candidate_papers = database.search_papers(
+        sessions=sessions,
+        years=years,
+        conferences=conferences,
+        limit=0,
+    )
+    candidate_by_uid = {uid: paper for paper in candidate_papers if (uid := _safe_uid(paper))}
+    if not candidate_by_uid:
+        return {
+            "papers": [],
+            "count": 0,
+            "query": query,
+            "seed_count": 0,
+            "candidate_count": 0,
+            "algorithm": "personalized_pagerank",
+            "unsupported_filters": unsupported_filters or [],
+        }
+
+    try:
+        embeddings = _get_embeddings_for_papers(embeddings_manager, list(candidate_by_uid.keys()))
+    except Exception as exc:
+        logger.warning("Could not load stored embeddings for recommendations: %s", exc)
+        embeddings = {}
+    embedded_candidate_count = len(embeddings)
+
+    seed_papers, exact_seed_uids = _build_seed_papers(
+        database=database,
+        query=query,
+        field_filters=field_filters,
+        remaining_query=remaining_query,
+        sessions=sessions,
+        years=years,
+        conferences=conferences,
+    )
+    seed_papers = {uid: paper for uid, paper in seed_papers.items() if uid in candidate_by_uid}
+    exact_seed_uids = {uid for uid in exact_seed_uids if uid in candidate_by_uid}
+
+    semantic_scores: Dict[str, float] = {}
+    semantic_seed_scores: Dict[str, float] = {}
+    query_embedding: Optional[List[float]] = None
+    if semantic_query and embeddings:
+        try:
+            query_embedding = embeddings_manager.generate_embedding(semantic_query)
+        except Exception as exc:
+            logger.warning("Could not generate query embedding for recommendations: %s", exc)
+
+    paper_ids = [uid for uid in candidate_by_uid if uid in embeddings]
+    if query_embedding is not None:
+        matrix = np.asarray([embeddings[uid] for uid in paper_ids], dtype=float)
+        similarities = _cosine_similarity_to_query(matrix, query_embedding)
+        semantic_scores = {uid: max(0.0, float(score)) for uid, score in zip(paper_ids, similarities)}
+        semantic_seed_count = min(24, len(paper_ids))
+        if semantic_seed_count:
+            top_indices = np.argsort(similarities)[-semantic_seed_count:]
+            semantic_seed_scores = {
+                paper_ids[int(idx)]: max(0.01, float(similarities[int(idx)]))
+                for idx in top_indices
+                if float(similarities[int(idx)]) > 0
+            }
+
+    if not seed_papers and not semantic_seed_scores:
+        return {
+            "papers": [],
+            "count": 0,
+            "query": query,
+            "seed_count": 0,
+            "candidate_count": len(candidate_by_uid),
+            "embedded_candidate_count": embedded_candidate_count,
+            "algorithm": "personalized_pagerank",
+            "unsupported_filters": unsupported_filters or [],
+            "warning": "No seed papers or semantic seed matches were found for the recommendation graph.",
+        }
+
+    graph = _build_graph(candidate_by_uid, embeddings)
+    personalization, seed_context = _build_personalization(
+        query=query,
+        field_filters=field_filters,
+        seed_papers=seed_papers,
+        semantic_seed_scores=semantic_seed_scores,
+    )
+    ranks = personalized_pagerank(graph, personalization)
+    paper_rank_scores = {uid: ranks.get(_paper_node(uid), 0.0) for uid in candidate_by_uid}
+    rank_norm = _normalise_scores(paper_rank_scores)
+    semantic_norm = _normalise_scores(semantic_scores)
+
+    scored: List[Tuple[float, str]] = []
+    for uid in candidate_by_uid:
+        if uid in exact_seed_uids:
+            continue
+        pr = rank_norm.get(uid, 0.0)
+        semantic = semantic_norm.get(uid, 0.0)
+        final = 0.75 * pr + 0.25 * semantic if semantic_norm else pr
+        if final > 0:
+            scored.append((final, uid))
+
+    scored.sort(key=lambda item: item[0], reverse=True)
+
+    recommendations: List[Dict[str, Any]] = []
+    for final_score, uid in scored[:limit]:
+        paper = dict(candidate_by_uid[uid])
+        pagerank_score = rank_norm.get(uid, 0.0)
+        semantic_score = semantic_norm.get(uid, 0.0)
+        paper["recommendation_score"] = final_score
+        paper["pagerank_score"] = pagerank_score
+        paper["semantic_score"] = semantic_score
+        paper["recommendation_reasons"] = _recommendation_reasons(
+            paper=paper,
+            seed_context=seed_context,
+            semantic_score=semantic_score,
+            pagerank_score=pagerank_score,
+        )
+        recommendations.append(paper)
+
+    return {
+        "papers": recommendations,
+        "count": len(recommendations),
+        "query": query,
+        "seed_count": len(seed_papers) + len(semantic_seed_scores),
+        "direct_seed_count": len(exact_seed_uids),
+        "candidate_count": len(candidate_by_uid),
+        "embedded_candidate_count": embedded_candidate_count,
+        "algorithm": "personalized_pagerank",
+        "recommendation_mode": "hybrid_graph" if embedded_candidate_count else "metadata_graph",
+        "limit": limit,
+        "unsupported_filters": unsupported_filters or [],
+        "warning": None
+        if embedded_candidate_count
+        else "No stored embeddings were found, so recommendations used metadata-only PageRank.",
+    }
+
+
+def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+    if not match:
+        return None
+    try:
+        parsed = json.loads(match.group(0))
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def explain_recommendations(
+    embeddings_manager: Any,
+    query: str,
+    papers: List[Dict[str, Any]],
+    top_n: int = 10,
+) -> Dict[str, Any]:
+    """
+    Ask the configured chat model to explain the top recommendations.
+
+    The function mutates the provided paper dictionaries by adding
+    ``llm_explanation`` when a parseable explanation is returned.
+    """
+    if top_n <= 0 or not papers:
+        return {"explained_count": 0}
+
+    config = get_config()
+    top_papers = papers[:top_n]
+    payload = [
+        {
+            "uid": paper.get("uid"),
+            "title": paper.get("title"),
+            "authors": paper.get("authors", []),
+            "year": paper.get("year"),
+            "conference": paper.get("conference"),
+            "score": round(float(paper.get("recommendation_score", 0.0)), 4),
+            "graph_reasons": paper.get("recommendation_reasons", []),
+            "abstract": (paper.get("abstract") or "")[:900],
+        }
+        for paper in top_papers
+    ]
+
+    system_message = (
+        "You explain research-paper recommendations. Return only valid JSON with the shape "
+        '{"explanations":[{"uid":"...","explanation":"one concise sentence"}]}. '
+        "Do not invent facts that are not present in the provided paper data."
+    )
+    user_message = (
+        f"Search/query seed: {query}\n\n"
+        "Explain why each recommended paper may be interesting to the user. "
+        "Use the graph reasons and abstract/title evidence.\n\n"
+        f"Papers:\n{json.dumps(payload, ensure_ascii=False)}"
+    )
+
+    try:
+        response = embeddings_manager.openai_client.chat.completions.create(
+            model=config.chat_model,
+            messages=[
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=0.2,
+            max_tokens=1400,
+        )
+        content = response.choices[0].message.content or ""
+        parsed = _extract_json_object(content)
+        if not parsed:
+            return {"explained_count": 0, "raw_explanation": content}
+
+        by_uid = {str(paper.get("uid")): paper for paper in top_papers}
+        explained = 0
+        for item in parsed.get("explanations", []):
+            uid = str(item.get("uid", ""))
+            explanation = str(item.get("explanation", "")).strip()
+            if uid in by_uid and explanation:
+                by_uid[uid]["llm_explanation"] = explanation
+                explained += 1
+        return {"explained_count": explained}
+    except Exception as exc:
+        logger.warning("LLM recommendation explanation failed: %s", exc)
+        return {"explained_count": 0, "error": str(exc)}

--- a/src/abstracts_explorer/web_ui/app.py
+++ b/src/abstracts_explorer/web_ui/app.py
@@ -22,6 +22,11 @@ from abstracts_explorer.rag import RAGChat
 from abstracts_explorer.config import get_config
 from abstracts_explorer.export_utils import export_papers_to_zip
 from abstracts_explorer.paper_utils import extract_top_keywords
+from abstracts_explorer.recommendations import (
+    DEFAULT_RECOMMENDATION_LIMIT,
+    explain_recommendations,
+    recommend_papers,
+)
 
 # Import version
 try:
@@ -551,6 +556,73 @@ def search():
         return jsonify(response_data)
     except Exception as e:
         logger.error(f"Error in search endpoint: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/recommendations", methods=["POST"])
+def recommendations():
+    """
+    Recommend papers using Personalized PageRank over paper metadata and embeddings.
+
+    Expected JSON body:
+    - query: str - Search or seed query
+    - limit: int - Maximum recommendation count (default and cap: 50)
+    - sessions: list[str] - Filter by sessions (optional)
+    - years: list[int] - Filter by years (optional)
+    - conferences: list[str] - Filter by conferences (optional)
+    - institutions: list[str] - Currently reported as unsupported; schema has no affiliation column
+    - explain_top_n: int - Ask the chat model to explain the top N, capped at 10
+    """
+    try:
+        data = request.get_json()
+        query = data.get("query", "")
+        if not query:
+            return jsonify({"error": "Query is required"}), 400
+
+        limit = min(DEFAULT_RECOMMENDATION_LIMIT, max(1, int(data.get("limit", DEFAULT_RECOMMENDATION_LIMIT))))
+        sessions = data.get("sessions", [])
+        years = data.get("years", [])
+        conferences = data.get("conferences", [])
+        institutions = data.get("institutions", [])
+        explain_top_n = min(10, max(0, int(data.get("explain_top_n", 0))))
+
+        unsupported_filters = []
+        if institutions:
+            unsupported_filters.append("institutions")
+
+        database = get_database()
+        em = get_embeddings_manager()
+        result = recommend_papers(
+            database=database,
+            embeddings_manager=em,
+            query=query,
+            sessions=sessions,
+            years=years,
+            conferences=conferences,
+            limit=limit,
+            unsupported_filters=unsupported_filters,
+        )
+
+        explanation_metadata = {"explained_count": 0}
+        if explain_top_n > 0 and result.get("papers"):
+            explanation_metadata = explain_recommendations(
+                embeddings_manager=em,
+                query=query,
+                papers=result["papers"],
+                top_n=explain_top_n,
+            )
+
+        papers = result.get("papers", [])
+        response_data = {
+            **result,
+            "use_embeddings": True,
+            "is_recommendation": True,
+            "related_topics": extract_top_keywords(papers),
+            "explanations": explanation_metadata,
+        }
+        return jsonify(response_data)
+    except Exception as e:
+        logger.error(f"Error in recommendations endpoint: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 

--- a/src/abstracts_explorer/web_ui/static/app.js
+++ b/src/abstracts_explorer/web_ui/static/app.js
@@ -138,6 +138,29 @@ function setupModalEventListeners() {
             localStorage.setItem('searchDistanceThreshold', this.value);
         });
     }
+
+    const recommendationsToggle = document.getElementById('recommendations-toggle');
+    const explainToggle = document.getElementById('recommendations-explain-toggle');
+    if (recommendationsToggle) {
+        recommendationsToggle.checked = localStorage.getItem('useGraphRecommendations') === 'true';
+        recommendationsToggle.addEventListener('change', function () {
+            localStorage.setItem('useGraphRecommendations', String(this.checked));
+            if (explainToggle) {
+                explainToggle.disabled = !this.checked;
+                if (!this.checked) {
+                    explainToggle.checked = false;
+                    localStorage.setItem('explainGraphRecommendations', 'false');
+                }
+            }
+        });
+    }
+    if (explainToggle) {
+        explainToggle.checked = localStorage.getItem('explainGraphRecommendations') === 'true';
+        explainToggle.disabled = recommendationsToggle ? !recommendationsToggle.checked : true;
+        explainToggle.addEventListener('change', function () {
+            localStorage.setItem('explainGraphRecommendations', String(this.checked));
+        });
+    }
 }
 
 /**

--- a/src/abstracts_explorer/web_ui/static/modules/paper-card.js
+++ b/src/abstracts_explorer/web_ui/static/modules/paper-card.js
@@ -112,6 +112,30 @@ export function formatPaperCard(paper, options = {}) {
     if (paper.distance !== undefined) {
         metadata += `<span class="px-2 py-1 bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 text-xs rounded-full" title="Similarity score: how closely this paper matches your search query (-1 = no match, 1 = perfect match)"><i class="fas fa-chart-line mr-1"></i>${(1 - paper.distance).toFixed(compact ? 2 : 3)}</span>`;
     }
+    if (paper.recommendation_score !== undefined) {
+        metadata += `<span class="px-2 py-1 bg-emerald-100 dark:bg-emerald-900/50 text-emerald-700 dark:text-emerald-300 text-xs rounded-full ml-1" title="Personalized PageRank recommendation score"><i class="fas fa-project-diagram mr-1"></i>${Number(paper.recommendation_score).toFixed(compact ? 2 : 3)}</span>`;
+    }
+
+    let recommendationHtml = '';
+    const reasons = Array.isArray(paper.recommendation_reasons) ? paper.recommendation_reasons : [];
+    if (!compact && (reasons.length > 0 || paper.llm_explanation)) {
+        const reasonHtml = reasons.length > 0 ? `
+            <div class="flex flex-wrap gap-2 mb-2">
+                ${reasons.map(reason => `<span class="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs rounded-full"><i class="fas fa-link mr-1"></i>${escapeHtml(reason)}</span>`).join('')}
+            </div>
+        ` : '';
+        const explanationHtml = paper.llm_explanation ? `
+            <p class="text-sm text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg px-3 py-2">
+                <i class="fas fa-lightbulb mr-1"></i>${escapeHtml(paper.llm_explanation)}
+            </p>
+        ` : '';
+        recommendationHtml = `
+            <div class="mt-3 pt-3 border-t dark:border-gray-700">
+                ${reasonHtml}
+                ${explanationHtml}
+            </div>
+        `;
+    }
 
     const cardId = idPrefix ? `id="${idPrefix}"` : '';
     const cardClasses = compact
@@ -149,6 +173,7 @@ export function formatPaperCard(paper, options = {}) {
             ${buildUrlBadges(paper, compact)}
             ${metadata ? `<div class="${compact ? 'mb-2' : 'mb-3'}">${metadata}</div>` : ''}
             ${abstractHtml}
+            ${recommendationHtml}
             ${!compact && paper.distance !== undefined && !metadata.includes('chart-line') ? `
                 <div class="mt-3 pt-3 border-t dark:border-gray-700">
                     <span class="text-xs text-gray-500 dark:text-gray-400">

--- a/src/abstracts_explorer/web_ui/static/modules/search.js
+++ b/src/abstracts_explorer/web_ui/static/modules/search.js
@@ -20,6 +20,10 @@ export async function searchPapers() {
     const limit = parseInt(document.getElementById('limit-select').value);
     const distanceThresholdInput = document.getElementById('distance-threshold-input');
     const distanceThreshold = distanceThresholdInput ? parseFloat(distanceThresholdInput.value) : undefined;
+    const recommendationsToggle = document.getElementById('recommendations-toggle');
+    const explainToggle = document.getElementById('recommendations-explain-toggle');
+    const useRecommendations = recommendationsToggle ? recommendationsToggle.checked : false;
+    const explainRecommendations = explainToggle ? explainToggle.checked : false;
 
     // Get multiple selected values from multi-select dropdowns
     const sessionSelect = document.getElementById('session-filter');
@@ -49,7 +53,7 @@ export async function searchPapers() {
         const requestBody = {
             query,
             use_embeddings: true,
-            limit
+            limit: useRecommendations ? 50 : limit
         };
 
         // Include distance threshold if available and valid
@@ -72,7 +76,12 @@ export async function searchPapers() {
             requestBody.conferences = [selectedConference];
         }
 
-        const response = await fetch(`${API_BASE}/api/search`, {
+        if (useRecommendations && explainRecommendations) {
+            requestBody.explain_top_n = 10;
+        }
+
+        const endpoint = useRecommendations ? '/api/recommendations' : '/api/search';
+        const response = await fetch(`${API_BASE}${endpoint}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -113,12 +122,20 @@ export function displaySearchResults(data) {
     // Display results header
     let html = `
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 mb-4">
-            <div class="flex items-center justify-between">
+            <div class="flex items-start justify-between gap-4">
                 <div>
-                    <span class="text-sm text-gray-600 dark:text-gray-400">${data.total_similar != null ? `Showing the <strong>${data.count}</strong> best matches out of <strong>${data.total_similar}</strong> similar papers` : `Found <strong>${data.count}</strong> papers`}</span>
+                    <span class="text-sm text-gray-600 dark:text-gray-400">${formatResultsSummary(data)}</span>
                     ${data.use_embeddings ? '<span class="ml-2 px-2 py-1 bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 text-xs rounded-full">LLM-Powered</span>' : ''}
+                    ${data.is_recommendation ? '<span class="ml-2 px-2 py-1 bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-xs rounded-full">Personalized PageRank</span>' : ''}
+                    ${data.explanations && data.explanations.explained_count > 0 ? `<span class="ml-2 px-2 py-1 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-xs rounded-full">${data.explanations.explained_count} explained</span>` : ''}
                 </div>
             </div>
+            ${data.warning ? `<p class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">${escapeHtml(data.warning)}</p>` : ''}
+            ${data.unsupported_filters && data.unsupported_filters.length > 0 ? `
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    Unsupported filters ignored: ${data.unsupported_filters.map(escapeHtml).join(', ')}
+                </p>
+            ` : ''}
             ${data.related_topics && data.related_topics.length > 0 ? `
             <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Related Topics</span>
@@ -145,6 +162,19 @@ export function displaySearchResults(data) {
     }
 
     resultsDiv.innerHTML = html;
+}
+
+function formatResultsSummary(data) {
+    if (data.is_recommendation) {
+        const seedText = data.direct_seed_count
+            ? `, excluding ${data.direct_seed_count} direct seed paper${data.direct_seed_count === 1 ? '' : 's'}`
+            : '';
+        return `Showing <strong>${data.count}</strong> recommended papers from <strong>${data.candidate_count || 0}</strong> candidates${seedText}`;
+    }
+    if (data.total_similar != null) {
+        return `Showing the <strong>${data.count}</strong> best matches out of <strong>${data.total_similar}</strong> similar papers`;
+    }
+    return `Found <strong>${data.count}</strong> papers`;
 }
 
 /**

--- a/src/abstracts_explorer/web_ui/templates/index.html
+++ b/src/abstracts_explorer/web_ui/templates/index.html
@@ -463,6 +463,18 @@
                         <i class="fas fa-search mr-2"></i>Search
                     </button>
                 </div>
+                <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-gray-700 dark:text-gray-300">
+                    <label class="inline-flex items-center gap-2 cursor-pointer" title="Use graph recommendations instead of the standard ranked search results">
+                        <input type="checkbox" id="recommendations-toggle"
+                            class="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-600">
+                        <span><i class="fas fa-project-diagram mr-1 text-purple-600 dark:text-purple-400"></i>Graph recommendations</span>
+                    </label>
+                    <label class="inline-flex items-center gap-2 cursor-pointer" title="Ask the configured chat model to explain the top 10 recommendations">
+                        <input type="checkbox" id="recommendations-explain-toggle"
+                            class="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-600">
+                        <span><i class="fas fa-lightbulb mr-1 text-amber-500"></i>Explain top 10</span>
+                    </label>
+                </div>
 
                 <!-- Hidden filter elements for search (used by JavaScript) -->
                 <div class="hidden">

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,192 @@
+from abstracts_explorer.recommendations import personalized_pagerank, recommend_papers
+
+
+class FakeCollection:
+    def __init__(self, embeddings):
+        self.embeddings = embeddings
+
+    def get(self, ids=None, include=None):
+        ids = ids or list(self.embeddings)
+        found_ids = [uid for uid in ids if uid in self.embeddings]
+        return {
+            "ids": found_ids,
+            "embeddings": [self.embeddings[uid] for uid in found_ids],
+        }
+
+
+class FakeEmbeddingsManager:
+    def __init__(self, embeddings, query_embedding=None):
+        self.collection = FakeCollection(embeddings)
+        self.query_embedding = query_embedding or [1.0, 0.0]
+
+    def generate_embedding(self, text):
+        return self.query_embedding
+
+
+class FakeDatabase:
+    def __init__(self, papers):
+        self.papers = papers
+
+    def search_papers(
+        self,
+        keyword=None,
+        field_filters=None,
+        sessions=None,
+        years=None,
+        conferences=None,
+        limit=100,
+        **kwargs,
+    ):
+        results = list(self.papers)
+
+        if sessions:
+            results = [paper for paper in results if paper.get("session") in sessions]
+        if years:
+            results = [paper for paper in results if paper.get("year") in years]
+        if conferences:
+            results = [paper for paper in results if paper.get("conference") in conferences]
+        if field_filters:
+            for field, value in field_filters.items():
+                needle = str(value).lower()
+                filtered = []
+                for paper in results:
+                    field_value = paper.get(field)
+                    if isinstance(field_value, list):
+                        haystack = " ".join(str(item) for item in field_value).lower()
+                    else:
+                        haystack = str(field_value or "").lower()
+                    if needle in haystack:
+                        filtered.append(paper)
+                results = filtered
+        if keyword:
+            needle = keyword.lower()
+            results = [
+                paper
+                for paper in results
+                if needle in (paper.get("title") or "").lower()
+                or needle in (paper.get("abstract") or "").lower()
+                or needle in " ".join(paper.get("keywords") or []).lower()
+            ]
+
+        if limit:
+            return results[:limit]
+        return results
+
+
+def test_personalized_pagerank_biases_toward_seed_neighborhood():
+    graph = {
+        "seed": {"near": 1.0},
+        "near": {"seed": 1.0, "far": 0.1},
+        "far": {"near": 0.1},
+    }
+
+    ranks = personalized_pagerank(graph, {"seed": 1.0})
+
+    assert ranks["near"] > ranks["far"]
+    assert ranks["seed"] > 0
+
+
+def test_recommend_papers_excludes_direct_author_seed_and_returns_coauthor_neighbor():
+    papers = [
+        {
+            "uid": "p1",
+            "title": "Alice and Bob seed paper",
+            "authors": ["Alice", "Bob"],
+            "abstract": "Seed work about scientific agents.",
+            "keywords": ["agents"],
+            "session": "Agents",
+            "year": 2026,
+            "conference": "HAICON",
+        },
+        {
+            "uid": "p2",
+            "title": "Bob follow-up paper",
+            "authors": ["Bob"],
+            "abstract": "Related work by a coauthor.",
+            "keywords": ["agents"],
+            "session": "Agents",
+            "year": 2026,
+            "conference": "HAICON",
+        },
+        {
+            "uid": "p3",
+            "title": "Distant paper",
+            "authors": ["Carol"],
+            "abstract": "A less connected topic.",
+            "keywords": ["biology"],
+            "session": "Bio",
+            "year": 2026,
+            "conference": "HAICON",
+        },
+    ]
+    embeddings = {
+        "p1": [1.0, 0.0],
+        "p2": [0.95, 0.05],
+        "p3": [0.0, 1.0],
+    }
+
+    result = recommend_papers(
+        database=FakeDatabase(papers),
+        embeddings_manager=FakeEmbeddingsManager(embeddings),
+        query='authors:"Alice"',
+        conferences=["HAICON"],
+        years=[2026],
+        limit=2,
+    )
+
+    returned_ids = [paper["uid"] for paper in result["papers"]]
+    assert "p1" not in returned_ids
+    assert returned_ids[0] == "p2"
+    assert result["direct_seed_count"] == 1
+    assert result["algorithm"] == "personalized_pagerank"
+
+
+def test_recommend_papers_falls_back_to_metadata_graph_without_embeddings():
+    papers = [
+        {
+            "uid": "p1",
+            "title": "Alice and Bob seed paper",
+            "authors": ["Alice", "Bob"],
+            "abstract": "Seed work about scientific agents.",
+            "keywords": ["agents"],
+            "session": "Agents",
+            "year": 2026,
+            "conference": "HAICON",
+        },
+        {
+            "uid": "p2",
+            "title": "Bob follow-up paper",
+            "authors": ["Bob"],
+            "abstract": "Related work by a coauthor.",
+            "keywords": ["agents"],
+            "session": "Agents",
+            "year": 2026,
+            "conference": "HAICON",
+        },
+        {
+            "uid": "p3",
+            "title": "Distant paper",
+            "authors": ["Carol"],
+            "abstract": "A less connected topic.",
+            "keywords": ["biology"],
+            "session": "Bio",
+            "year": 2026,
+            "conference": "HAICON",
+        },
+    ]
+
+    result = recommend_papers(
+        database=FakeDatabase(papers),
+        embeddings_manager=FakeEmbeddingsManager({}),
+        query='authors:"Alice"',
+        conferences=["HAICON"],
+        years=[2026],
+        limit=2,
+    )
+
+    returned_ids = [paper["uid"] for paper in result["papers"]]
+    assert "p1" not in returned_ids
+    assert returned_ids[0] == "p2"
+    assert result["embedded_candidate_count"] == 0
+    assert result["recommendation_mode"] == "metadata_graph"
+    assert "metadata-only PageRank" in result["warning"]


### PR DESCRIPTION
Made with @raeesay

- Added a new recommendations API endpoint to suggest papers using Personalized PageRank.
- Integrated recommendation functionality into the web UI with toggle options for graph recommendations and explanations.
- Enhanced paper card display to show recommendation scores and reasons.
- Updated search functionality to support recommendations and explanations.
- Introduced tests for recommendation logic and behavior.