### PR TITLE
fix(rag): ensure selected conference propagates to chat system prompt

### DIFF
--- a/src/abstracts_explorer/rag.py
+++ b/src/abstracts_explorer/rag.py
@@ -16,7 +16,7 @@ from typing import List, Dict, Optional, Any
 import httpx
 
 from pydantic_ai import Agent, RunContext, Tool
-from pydantic_ai.messages import ModelMessage
+from pydantic_ai.messages import ModelMessage, ModelRequest
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
@@ -630,26 +630,31 @@ class RAGChat:
                 max_tokens=1000,
             )
 
-            # Prepare run kwargs
-            run_kwargs: Dict[str, Any] = {
-                "deps": deps,
-                "model_settings": settings,
-            }
-
-            # Pass message history for conversation context
-            if self._message_history:
-                run_kwargs["message_history"] = self._message_history
-
-            # Set per-run instructions: use explicit system_prompt if provided,
-            # otherwise build context-aware instructions with conference information
+            # Build instructions first so we can update message history
             if system_prompt is not None:
-                run_kwargs["instructions"] = system_prompt
+                instructions = system_prompt
             else:
-                run_kwargs["instructions"] = self._build_instructions(
+                instructions = self._build_instructions(
                     conferences=conferences,
                     years=years,
                     available_conferences=available_conferences,
                 )
+
+            # Prepare run kwargs
+            run_kwargs: Dict[str, Any] = {
+                "deps": deps,
+                "model_settings": settings,
+                "instructions": instructions,
+            }
+
+            # Pass message history for conversation context, updating stale
+            # system prompt in the first request to reflect current conference.
+            # Pydantic AI doesn't re-add system prompts on continuation turns,
+            # so the first ModelRequest in history may contain outdated
+            # conference context from a prior turn.
+            if self._message_history:
+                self._update_message_history_instructions(instructions)
+                run_kwargs["message_history"] = self._message_history
 
             # Run the agent
             result = self.agent.run_sync(question, **run_kwargs)
@@ -723,7 +728,10 @@ class RAGChat:
                     "model_settings": settings,
                 }
                 if self._message_history:
+                    base_instructions = self._build_base_instructions()
+                    self._update_message_history_instructions(base_instructions)
                     run_kwargs["message_history"] = self._message_history
+                    run_kwargs["instructions"] = base_instructions
 
                 result = self.agent.run_sync(message, **run_kwargs)
                 self._message_history = result.all_messages()
@@ -735,6 +743,21 @@ class RAGChat:
                 }
             except Exception as e:
                 raise RAGError(f"Chat failed: {str(e)}") from e
+
+    def _update_message_history_instructions(self, instructions: str) -> None:
+        """
+        Update the instructions on the first ModelRequest in message history.
+
+        Pydantic AI does not re-add system prompts on continuation turns.
+        When the user changes the conference in the UI, the instructions need to
+        reflect the new conference, but the first ModelRequest in
+        ``_message_history`` still holds the stale system prompt from the prior
+        conference.  This method walks the history and updates the ``instructions``
+        field on every ModelRequest so the LLM sees consistent context.
+        """
+        for msg in self._message_history:
+            if isinstance(msg, ModelRequest):
+                msg.instructions = instructions
 
     def reset_conversation(self):
         """

--- a/src/abstracts_explorer/web_ui/static/modules/chat.js
+++ b/src/abstracts_explorer/web_ui/static/modules/chat.js
@@ -387,7 +387,8 @@ export async function resetChat() {
 
         const messagesDiv = document.getElementById('chat-messages');
         messagesDiv.innerHTML = '';
-        addChatMessage('Conversation reset. How can I help you explore NeurIPS abstracts?', 'assistant');
+        const conf = getSelectedConference() || 'conference';
+        addChatMessage(`Conversation reset. How can I help you explore ${conf} abstracts?`, 'assistant');
 
         // Re-show the MCP tools hint
         _hasUserSentMessage = false;


### PR DESCRIPTION
RAG chat always assumed NeurIPS 2025 even after switching conferences in the UI. The root cause was that Pydantic AI doesn't re-add system prompts on continuation turns, so the first ModelRequest in message history retained stale conference context from the previous turn. The LLM received two conflicting system prompts and followed the stale one.
- Update instructions on all ModelRequest messages in history before each turn so the LLM sees consistent, current conference context.
- Apply fix to both query() and chat() (no-tool) paths in RAGChat.
- Replace hardcoded "NeurIPS" in resetChat() greeting with the currently selected conference.