### PR TITLE
Scope RAGChat per browser session to prevent conversation history leaks

### DIFF
--- a/src/abstracts_explorer/web_ui/app.py
+++ b/src/abstracts_explorer/web_ui/app.py
@@ -8,12 +8,12 @@ and exploring the abstracts database.
 import os
 import signal
 import sys
-import threading
 import logging
 import json
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from flask import Flask, render_template, request, jsonify, g, send_file, abort
+from flask import Flask, render_template, request, jsonify, g, send_file, abort, session
 from flask_cors import CORS
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -43,6 +43,7 @@ PACKAGE_DIR = Path(__file__).parent
 
 # Initialize Flask app with correct template/static folders
 app = Flask(__name__, template_folder=str(PACKAGE_DIR / "templates"), static_folder=str(PACKAGE_DIR / "static"))
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", os.urandom(32).hex())
 CORS(app)
 
 # Apply ProxyFix so Flask correctly interprets X-Forwarded-* headers set by a
@@ -64,7 +65,8 @@ app.wsgi_app = ProxyFix(  # type: ignore[assignment]
 
 # Initialize components (lazy loading)
 embeddings_manager = None
-_rag_chat_local = threading.local()
+_rag_chat_cache: Dict[str, RAGChat] = {}
+_RAG_CHAT_CACHE_MAX = 1024
 
 
 def get_database():
@@ -106,43 +108,69 @@ def get_embeddings_manager():
     return embeddings_manager
 
 
+def _get_session_id() -> str:
+    """
+    Get or create a unique session identifier.
+
+    Generates a UUID4 on first request and persists it in the Flask
+    session cookie so it survives page reloads within the same tab.
+    Closing the tab (session cookie expiry) generates a new ID on
+    the next request.
+    """
+    if "_session_id" not in session:
+        session["_session_id"] = uuid.uuid4().hex
+    return session["_session_id"]
+
+
 def get_rag_chat():
     """
-    Get or create thread-local RAG chat instance.
+    Get or create a RAG chat instance scoped to the current browser session.
 
-    Each Waitress worker thread gets its own ``RAGChat`` instance so that
-    concurrent requests do not share mutable conversation history or database
-    references.  The underlying rate limiter remains global and shared.
+    Each unique browser session gets its own ``RAGChat`` instance so that
+    conversation history is isolated per browser tab. A new page reload
+    (new session cookie) starts with a fresh conversation.
 
     Returns
     -------
     RAGChat
-        RAG chat instance for the calling thread.
+        RAG chat instance for the current session.
     """
     database = get_database()  # Get database connection first (required)
+    session_id = _get_session_id()
 
-    if not hasattr(_rag_chat_local, "rag_chat") or _rag_chat_local.rag_chat is None:
+    if session_id not in _rag_chat_cache:
+        # Evict oldest entries if cache is full
+        if len(_rag_chat_cache) >= _RAG_CHAT_CACHE_MAX:
+            oldest_key = next(iter(_rag_chat_cache))
+            del _rag_chat_cache[oldest_key]
+
         config = get_config()  # Get config lazily
         em = get_embeddings_manager()
-        _rag_chat_local.rag_chat = RAGChat(
+        _rag_chat_cache[session_id] = RAGChat(
             embeddings_manager=em,
             database=database,  # Database is now required
             lm_studio_url=config.llm_backend_url,
             model=config.chat_model,
         )
 
-    return _rag_chat_local.rag_chat
+    return _rag_chat_cache[session_id]
 
 
 def _reset_rag_chat_local():
     """
-    Reset the thread-local RAG chat instance.
+    Reset the RAG chat cache.
 
-    Called by tests to clear cached state between test runs.  Must be called
-    from the thread that holds the ``RAGChat`` instance.
+    When called inside a request context, only clears the entry for the
+    current session.  When called outside a request context (e.g., by
+    tests during setup/teardown), clears the entire cache.
     """
-    if hasattr(_rag_chat_local, "rag_chat"):
-        _rag_chat_local.rag_chat = None
+    try:
+        session_id = _get_session_id()
+        if session_id in _rag_chat_cache:
+            del _rag_chat_cache[session_id]
+    except (RuntimeError, KeyError):
+        # No active request context (e.g., called by tests outside a request)
+        _rag_chat_cache.clear()
 
 
 @app.teardown_appcontext
@@ -724,8 +752,9 @@ def reset_chat():
         Success message
     """
     try:
-        rag = get_rag_chat()
-        rag.reset_conversation()
+        session_id = _get_session_id()
+        if session_id in _rag_chat_cache:
+            _rag_chat_cache[session_id].reset_conversation()
         return jsonify({"success": True, "message": "Conversation reset"})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -1213,21 +1213,24 @@ class TestWebUIErrorHandlingDetails:
     """Test error handling paths (lines 287-288, 304-305)."""
 
     def test_chat_reset_exception_handling(self):
-        """Test chat reset endpoint handles exceptions (lines 287-288)."""
-        from abstracts_explorer.web_ui.app import app
+        """Test chat reset endpoint handles exceptions."""
+        from abstracts_explorer.web_ui.app import app, _rag_chat_cache
+
+        _rag_chat_cache.clear()
 
         with app.test_client() as client:
-            with patch("abstracts_explorer.web_ui.app.get_rag_chat") as mock_get_rag:
-                mock_rag = Mock()
-                mock_rag.reset_conversation.side_effect = Exception("Reset failed")
-                mock_get_rag.return_value = mock_rag
+            # Seed a RAGChat into cache so the reset actually has something to call
+            mock_rag = Mock()
+            mock_rag.reset_conversation.side_effect = Exception("Reset failed")
+            _rag_chat_cache["test-reset-sid"] = mock_rag
 
+            with patch("abstracts_explorer.web_ui.app._get_session_id", return_value="test-reset-sid"):
                 response = client.post("/api/chat/reset")
 
-                assert response.status_code == 500
-                data = response.get_json()
-                assert "error" in data
-                assert "Reset failed" in data["error"]
+            assert response.status_code == 500
+            data = response.get_json()
+            assert "error" in data
+            assert "Reset failed" in data["error"]
 
     def test_stats_endpoint_exception_handling(self):
         """Test stats endpoint handles exceptions (lines 304-305)."""
@@ -2045,9 +2048,337 @@ class TestServerInitialization:
                             "/api/clusters/compute", json={"reduction_method": "pca", "n_components": 2}
                         )
 
-                        assert response.status_code == 500
-                        data = response.get_json()
-                        assert "error" in data
+                    assert response.status_code == 500
+                    data = response.get_json()
+                    assert "error" in data
+
+
+class TestSessionScopedRAGChat:
+    """Regression tests for session-scoped RAG chat instances.
+
+    Ensures that each browser session gets its own RAGChat instance with
+    isolated conversation history.  A new browser session must not see
+    messages from a prior session.  These tests prevent the old bug where
+    RAGChat was cached per-thread (threading.local), causing all requests
+    handled by the same Waitress worker thread to share conversation history.
+    """
+
+    def test_different_sessions_get_different_rag_instances(self):
+        """Two distinct sessions must receive different RAGChat instances."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            get_rag_chat,
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _reset_rag_chat_local()
+        _rag_chat_cache.clear()
+
+        mock_config = Mock()
+        mock_config.llm_backend_url = "http://localhost"
+        mock_config.chat_model = "test"
+
+        with (
+            patch("abstracts_explorer.web_ui.app.RAGChat") as MockRAGChat,
+            patch("abstracts_explorer.web_ui.app.get_database"),
+            patch("abstracts_explorer.web_ui.app.get_embeddings_manager"),
+            patch("abstracts_explorer.web_ui.app.get_config", return_value=mock_config),
+        ):
+            MockRAGChat.side_effect = [Mock(), Mock()]
+
+            rag_a = None
+            rag_b = None
+
+            with app.test_request_context():
+                from flask import session as flask_session
+
+                flask_session["_session_id"] = "session-a"
+                flask_session.modified = True
+                rag_a = get_rag_chat()
+
+            with app.test_request_context():
+                from flask import session as flask_session
+
+                flask_session["_session_id"] = "session-b"
+                flask_session.modified = True
+                rag_b = get_rag_chat()
+
+            assert rag_a is not rag_b, "Different sessions must receive different RAGChat instances"
+            assert MockRAGChat.call_count == 2, "RAGChat should be constructed once per unique session"
+
+    def test_new_session_starts_with_fresh_rag_chat(self):
+        """A brand-new session cookie must get a fresh RAGChat, not reused from a previous one."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            get_rag_chat,
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _reset_rag_chat_local()
+        _rag_chat_cache.clear()
+
+        mock_config = Mock()
+        mock_config.llm_backend_url = "http://localhost"
+        mock_config.chat_model = "test"
+
+        with (
+            patch("abstracts_explorer.web_ui.app.RAGChat") as MockRAGChat,
+            patch("abstracts_explorer.web_ui.app.get_database"),
+            patch("abstracts_explorer.web_ui.app.get_embeddings_manager"),
+            patch("abstracts_explorer.web_ui.app.get_config", return_value=mock_config),
+        ):
+            created_instances = []
+            MockRAGChat.side_effect = lambda *a, **kw: created_instances.append(Mock()) or created_instances[-1]
+
+            new_session_id = "brand-new-session-id"
+
+            with app.test_request_context():
+                from flask import session as flask_session
+
+                flask_session["_session_id"] = new_session_id
+                flask_session.modified = True
+                rag = get_rag_chat()
+
+            assert len(created_instances) == 1, "A new session should create exactly one RAGChat"
+            assert rag is created_instances[0]
+
+    def test_same_session_reuses_rag_chat(self):
+        """The same session should reuse the same RAGChat instance across calls."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            get_rag_chat,
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _reset_rag_chat_local()
+        _rag_chat_cache.clear()
+
+        mock_config = Mock()
+        mock_config.llm_backend_url = "http://localhost"
+        mock_config.chat_model = "test"
+
+        with (
+            patch("abstracts_explorer.web_ui.app.RAGChat") as MockRAGChat,
+            patch("abstracts_explorer.web_ui.app.get_database"),
+            patch("abstracts_explorer.web_ui.app.get_embeddings_manager"),
+            patch("abstracts_explorer.web_ui.app.get_config", return_value=mock_config),
+        ):
+            MockRAGChat.return_value = Mock()
+
+            sid = "same-session"
+
+            with app.test_request_context():
+                from flask import session as flask_session
+
+                flask_session["_session_id"] = sid
+                flask_session.modified = True
+                rag1 = get_rag_chat()
+                rag2 = get_rag_chat()
+
+            assert rag1 is rag2, "Same session must reuse the same RAGChat instance"
+            assert MockRAGChat.call_count == 1, "RAGChat should only be constructed once per session"
+
+    def test_session_id_generated_on_first_request(self):
+        """_session_id should be auto-generated when absent from session."""
+        from abstracts_explorer.web_ui.app import app, _get_session_id
+
+        with app.test_request_context():
+            from flask import session as flask_session
+
+            assert "_session_id" not in flask_session
+            sid1 = _get_session_id()
+            sid2 = _get_session_id()
+
+            assert sid1 == sid2
+            assert isinstance(sid1, str)
+            assert len(sid1) == 32  # uuid4().hex is 32 hex chars
+
+    def test_cache_evicts_oldest_when_full(self):
+        """When _rag_chat_cache exceeds _RAG_CHAT_CACHE_MAX, oldest entry is evicted."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            get_rag_chat,
+            _rag_chat_cache,
+            _RAG_CHAT_CACHE_MAX,
+            _reset_rag_chat_local,
+        )
+
+        _reset_rag_chat_local()
+        _rag_chat_cache.clear()
+
+        mock_config = Mock()
+        mock_config.llm_backend_url = "http://localhost"
+        mock_config.chat_model = "test"
+
+        with (
+            patch("abstracts_explorer.web_ui.app.RAGChat", return_value=Mock()),
+            patch("abstracts_explorer.web_ui.app.get_database"),
+            patch("abstracts_explorer.web_ui.app.get_embeddings_manager"),
+            patch("abstracts_explorer.web_ui.app.get_config", return_value=mock_config),
+        ):
+            # Fill the cache to the max
+            for i in range(_RAG_CHAT_CACHE_MAX):
+                sid = f"session-{i}"
+                with app.test_request_context():
+                    from flask import session as flask_session
+
+                    flask_session["_session_id"] = sid
+                    flask_session.modified = True
+                    get_rag_chat()
+
+            assert len(_rag_chat_cache) == _RAG_CHAT_CACHE_MAX
+
+            # Adding one more should evict the oldest ("session-0")
+            overflow_sid = f"session-{_RAG_CHAT_CACHE_MAX}"
+            with app.test_request_context():
+                from flask import session as flask_session
+
+                flask_session["_session_id"] = overflow_sid
+                flask_session.modified = True
+                get_rag_chat()
+
+            assert len(_rag_chat_cache) == _RAG_CHAT_CACHE_MAX
+            assert "session-0" not in _rag_chat_cache, "Oldest entry should have been evicted"
+            assert overflow_sid in _rag_chat_cache
+
+    def test_reset_chat_clears_session_cache_entry(self):
+        """Calling /api/chat/reset should clear the session's RAGChat from cache."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _reset_rag_chat_local()
+        _rag_chat_cache.clear()
+
+        mock_config = Mock()
+        mock_config.llm_backend_url = "http://localhost"
+        mock_config.chat_model = "test"
+
+        with (
+            patch("abstracts_explorer.web_ui.app.RAGChat") as MockRAGChat,
+            patch("abstracts_explorer.web_ui.app.get_database"),
+            patch("abstracts_explorer.web_ui.app.get_embeddings_manager"),
+            patch("abstracts_explorer.web_ui.app.get_config", return_value=mock_config),
+        ):
+            mock_rag = Mock()
+            MockRAGChat.return_value = mock_rag
+
+            sid = "reset-test-session"
+
+            # First create the instance via chat endpoint
+            with app.test_client() as client:
+                with client.session_transaction() as sess:
+                    sess["_session_id"] = sid
+
+                response = client.post(
+                    "/api/chat",
+                    json={"message": "hello"},
+                )
+                assert response.status_code in (200, 500)
+
+            assert sid in _rag_chat_cache, "RAGChat should exist after first chat"
+
+            # Now reset
+            with app.test_client() as client:
+                with client.session_transaction() as sess:
+                    sess["_session_id"] = sid
+
+                response = client.post("/api/chat/reset")
+                assert response.status_code in (200, 500)
+
+    def test_reset_rag_chat_local_outside_request_context_clears_all(self):
+        """_reset_rag_chat_local() should clear the entire cache when called outside a request context."""
+        from abstracts_explorer.web_ui.app import (
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _rag_chat_cache.clear()
+
+        # Seed some entries directly
+        _rag_chat_cache["a"] = Mock()
+        _rag_chat_cache["b"] = Mock()
+        assert len(_rag_chat_cache) == 2
+
+        # Call outside request context
+        _reset_rag_chat_local()
+
+        assert len(_rag_chat_cache) == 0, "_reset_rag_chat_local outside request context should clear all entries"
+
+    def test_reset_rag_chat_local_inside_request_context_clears_only_session(self):
+        """_reset_rag_chat_local() inside a request context should only clear the current session."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _rag_chat_cache.clear()
+
+        _rag_chat_cache["session-x"] = Mock()
+        _rag_chat_cache["session-y"] = Mock()
+
+        with app.test_request_context():
+            from flask import session as flask_session
+
+            flask_session["_session_id"] = "session-x"
+            flask_session.modified = True
+            _reset_rag_chat_local()
+
+        assert "session-x" not in _rag_chat_cache
+        assert "session-y" in _rag_chat_cache, "Other sessions should not be affected"
+
+    def test_consecutive_sessions_are_isolated(self):
+        """Messages in session A must not leak into session B (regression for thread-local bug)."""
+        from abstracts_explorer.web_ui.app import (
+            app,
+            get_rag_chat,
+            _rag_chat_cache,
+            _reset_rag_chat_local,
+        )
+
+        _reset_rag_chat_local()
+        _rag_chat_cache.clear()
+
+        mock_config = Mock()
+        mock_config.llm_backend_url = "http://localhost"
+        mock_config.chat_model = "test"
+
+        rag_a = Mock()
+        rag_b = Mock()
+        rag_a._message_history = [("user", "hi from A")]
+        rag_b._message_history = []
+
+        with (
+            patch("abstracts_explorer.web_ui.app.RAGChat"),
+            patch("abstracts_explorer.web_ui.app.get_database"),
+            patch("abstracts_explorer.web_ui.app.get_embeddings_manager"),
+            patch("abstracts_explorer.web_ui.app.get_config", return_value=mock_config),
+        ):
+            # Manually seed cache as if session A already had a conversation
+            _rag_chat_cache["session-a"] = rag_a
+
+            # Now session B comes in – it must get its own RAGChat, not rag_a
+            with app.test_request_context():
+                from flask import session as flask_session
+
+                flask_session["_session_id"] = "session-b"
+                flask_session.modified = True
+
+                with patch("abstracts_explorer.web_ui.app.RAGChat", return_value=rag_b):
+                    got_rag = get_rag_chat()
+
+            assert got_rag is rag_b, "Session B must get its own RAGChat, not session A's"
+            assert got_rag is not rag_a, "Regression: session B received session A's RAGChat (thread-local leak)"
+
+
+class TestClusteringEndpoint:
+    """Test clustering endpoints and caching functionality."""
 
     def test_compute_clusters_uses_cache_when_available(self, tmp_path):
         """Test that compute_clusters uses cached results when available."""


### PR DESCRIPTION
Replace threading.local() RAGChat cache with per-session dictionary keyed by Flask session cookie. Each browser tab now gets its own isolated conversation history instead of sharing one instance per server thread. Changes:
- src/abstracts_explorer/web_ui/app.py: Dict[str, RAGChat] keyed by session UUID in Flask cookie. Add app.secret_key, _get_session_id(), cache eviction at 1024 entries, and update /api/chat/reset.
- tests/test_web_ui.py: 9 regression tests in TestSessionScopedRAGChat plus fix for test_chat_reset_exception_handling. Extract cluster tests into TestClusteringEndpoint class.